### PR TITLE
fix small bug in testhandler and improve it

### DIFF
--- a/lib/pwwka/test_handler.rb
+++ b/lib/pwwka/test_handler.rb
@@ -1,4 +1,12 @@
 module Pwwka
+  # A handler you can use to examine messages your app sends during tests.
+  #
+  # To use this:
+  #
+  # 1. Create an instance and arrange for `test_setup` to be called when
+  #    your tests are being setup (e.g.`def setup` or `before`)
+  # 2. Arrange for `test_teardown` to be called during teardown of your tests
+  # 3. Use the method `pop_message` to examine the message on the queue
   class TestHandler
 
     attr_reader :channel_connector
@@ -21,19 +29,35 @@ module Pwwka
     def test_queue
       @test_queue  ||= begin
                          test_queue  = channel.queue("test-queue", durable: true)
-                         test_queue.bind(topic_exchange, routing_key: "*.*")
+                         test_queue.bind(topic_exchange, routing_key: "#.#")
                          test_queue
                        end
     end
 
+    # Get the message on the queue as TestHandler::Message.
+    def pop_message
+      delivery_info, properties, payload = test_queue.pop
+      Message.new(delivery_info,
+                  properties,
+                  payload)
+    end
+
     def get_topic_message_payload_for_tests
-      delivery_info, properties, payload  = test_queue.pop
-      JSON.parse(payload)
+      deprecated!(:get_topic_message_payload_for_tests,
+                  "Use `pop_message.payload` instead")
+      pop_message.payload
     end
 
     def get_topic_message_properties_for_tests
-      delivery_info, properties, payload  = test_queue.pop
-      properties
+      deprecated!(:get_topic_message_properties_for_tests,
+                  "Use `pop_message.properties` instead")
+      pop_message.properties
+    end
+
+    def get_topic_message_delivery_info_for_tests
+      deprecated!(:get_topic_message_delivery_info_for_tests,
+                  "Use `pop_message.delivery_info` instead")
+      pop_message.delivery_info
     end
 
     def purge_test_queue
@@ -44,6 +68,34 @@ module Pwwka
       test_queue.delete
       topic_exchange.delete
       channel_connector.connection_close 
+    end
+
+    # Simple class to hold a popped message.
+    #
+    # You can either access the message contents directly, or splat
+    # it for the most commonly-needed aspects:
+    #
+    #     delivery_info, payload = @test_handler.pop_message
+    class Message
+      attr_reader :delivery_info, :properties, :payload
+      def initialize(delivery_info, properties, payload)
+        @delivery_info = delivery_info
+        @properties = properties
+        @raw_payload = payload
+        @payload = JSON.parse(@raw_payload)
+      end
+
+      # Returns the delivery_info, payload, properties, and raw_payload for splat
+      # magic.
+      def to_ary
+        [@delivery_info,@payload,@properties,@raw_payload]
+      end
+    end
+
+  private
+
+    def deprecated!(method,message)
+      warn "#{method} is deprecated: #{message}"
     end
 
   end

--- a/spec/transmitter_spec.rb
+++ b/spec/transmitter_spec.rb
@@ -10,15 +10,24 @@ describe Pwwka::Transmitter do
   after(:all) { @test_handler.test_teardown }
 
   let(:payload)     { Hash[:this, "that"] }
-  let(:routing_key) { "this.that" }
+  let(:routing_key) { "this.that.and.theother" }
 
   describe "#send_message!" do
 
-    it "should send the correct payload" do
-      success = Pwwka::Transmitter.new.send_message!(payload, routing_key)
-      expect(success).to be_truthy
-      received_payload = @test_handler.get_topic_message_payload_for_tests
-      expect(received_payload["this"]).to eq("that")
+    context "happy path" do
+      it "should send the correct payload" do
+        success = Pwwka::Transmitter.new.send_message!(payload, routing_key)
+        expect(success).to be_truthy
+        received_payload = @test_handler.pop_message.payload
+        expect(received_payload["this"]).to eq("that")
+      end
+
+      it "should delivery on the expected routing key" do
+        success = Pwwka::Transmitter.new.send_message!(payload, routing_key)
+        expect(success).to be_truthy
+        delivery_info = @test_handler.pop_message.delivery_info
+        expect(delivery_info.routing_key).to eq(routing_key)
+      end
     end
 
     it "should blow up if exception raised" do
@@ -34,7 +43,7 @@ describe Pwwka::Transmitter do
 
     it "should send the correct payload" do
       Pwwka::Transmitter.send_message!(payload, routing_key)
-      received_payload = @test_handler.get_topic_message_payload_for_tests
+      received_payload = @test_handler.pop_message.payload
       expect(received_payload["this"]).to eq("that")
     end
 
@@ -51,7 +60,7 @@ describe Pwwka::Transmitter do
 
     it "should send the correct payload" do
       Pwwka::Transmitter.send_message_safely(payload, routing_key)
-      received_payload = @test_handler.get_topic_message_payload_for_tests
+      received_payload = @test_handler.pop_message.payload
       expect(received_payload["this"]).to eq("that")
     end
 


### PR DESCRIPTION
- Docs about how to use it
- Have it bind to _all_ messages, not just `*.*`
- Deprecate the `get_topic_blah_blah` for a more streamlined API
