### PR TITLE
Don't blow up if delayed not configured in tests

### DIFF
--- a/lib/pwwka/test_handler.rb
+++ b/lib/pwwka/test_handler.rb
@@ -65,8 +65,10 @@ module Pwwka
       test_queue.delete
       channel_connector.topic_exchange.delete
       # delayed messages
-      channel_connector.delayed_queue.delete
-      channel_connector.delayed_exchange.delete
+      unless Pwwka.configuration.allow_delayed?
+        channel_connector.delayed_queue.delete
+        channel_connector.delayed_exchange.delete
+      end
 
       channel_connector.connection_close 
     end


### PR DESCRIPTION
This isn't checking if delayed is configured and so blows up in an after
hook where it's used.
