### PR TITLE
Provides a handler that simply queues a resque job

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -28,7 +28,20 @@ GEM
     json (1.8.1)
     minitest (5.4.2)
     mono_logger (1.1.0)
+    multi_json (1.10.1)
+    rack (1.6.0)
+    rack-protection (1.5.3)
+      rack
     rake (10.3.2)
+    redis (3.2.0)
+    redis-namespace (1.5.1)
+      redis (~> 3.0, >= 3.0.4)
+    resque (1.25.2)
+      mono_logger (~> 1.0)
+      multi_json (~> 1.0)
+      redis-namespace (~> 1.3)
+      sinatra (>= 0.9.2)
+      vegas (~> 0.1.2)
     rspec (3.1.0)
       rspec-core (~> 3.1.0)
       rspec-expectations (~> 3.1.0)
@@ -41,9 +54,16 @@ GEM
     rspec-mocks (3.1.3)
       rspec-support (~> 3.1.0)
     rspec-support (3.1.2)
+    sinatra (1.4.5)
+      rack (~> 1.4)
+      rack-protection (~> 1.4)
+      tilt (~> 1.3, >= 1.3.4)
     thread_safe (0.3.4)
+    tilt (1.4.1)
     tzinfo (1.2.2)
       thread_safe (~> 0.1)
+    vegas (0.1.11)
+      rack (>= 1.0.0)
 
 PLATFORMS
   ruby
@@ -51,4 +71,5 @@ PLATFORMS
 DEPENDENCIES
   pwwka!
   rake
+  resque
   rspec

--- a/lib/pwwka/queue_resque_job_handler.rb
+++ b/lib/pwwka/queue_resque_job_handler.rb
@@ -1,4 +1,4 @@
-require 'active_support/core_ext/string/inflections.rb'
+require 'active_support/core_ext/string/inflections'
 require 'resque'
 
 module Pwwka

--- a/lib/pwwka/queue_resque_job_handler.rb
+++ b/lib/pwwka/queue_resque_job_handler.rb
@@ -1,0 +1,19 @@
+require 'active_support/core_ext/string/inflections.rb'
+require 'resque'
+
+module Pwwka
+  # A handler that simply queues the payload into a Resque job.  This is useful
+  # if the code that should respond to a message needs to be managed by Resque, e.g.
+  # for the purposes of retry or better failure management.
+  #
+  # You should be able to use this directly from your handler configuration, e.g. for a Heroku-style `Procfile`:
+  #
+  #     my_handler: rake message_handler:receive HANDLER_KLASS=Pwwka::QueueResqueJobHandler JOB_KLASS=MyResqueJob QUEUE_NAME=my_queue ROUTING_KEY="my.key.completed"
+  #
+  # Note that this will not check the routing key, so you should be sure to specify the most precise ROUTING_KEY you can for handling the message.
+  class QueueResqueJobHandler
+    def self.handle!(delivery_info,properties,payload)
+      Resque.enqueue(ENV["JOB_KLASS"].constantize, payload)
+    end
+  end
+end

--- a/pwwka.gemspec
+++ b/pwwka.gemspec
@@ -24,4 +24,5 @@ Gem::Specification.new do |s|
   s.add_dependency("mono_logger")
   s.add_development_dependency("rake")
   s.add_development_dependency("rspec")
+  s.add_development_dependency("resque")
 end

--- a/spec/queue_resque_job_handler_spec.rb
+++ b/spec/queue_resque_job_handler_spec.rb
@@ -20,7 +20,7 @@ describe Pwwka::QueueResqueJobHandler do
 
     before do
       allow(Resque).to receive(:enqueue)
-      ENV["JOB_CLASS"] = MyTestJob.name
+      ENV["JOB_KLASS"] = MyTestJob.name
 
       described_class.handle!(delivery_info,properties,payload)
     end

--- a/spec/queue_resque_job_handler_spec.rb
+++ b/spec/queue_resque_job_handler_spec.rb
@@ -1,0 +1,36 @@
+require 'spec_helper'
+require 'pwwka/queue_resque_job_handler'
+
+class MyTestJob
+end
+
+describe Pwwka::QueueResqueJobHandler do
+
+  describe "::handle!" do
+    let(:job_class) { MyTestJob }
+    let(:delivery_info) { double("delivery info") }
+    let(:properties) { double("properties") }
+    let(:payload) {
+      {
+        "this" => "is",
+        "some" => true,
+        "payload" => 99,
+      }
+    }
+
+    before do
+      allow(Resque).to receive(:enqueue)
+      ENV["JOB_CLASS"] = MyTestJob.name
+
+      described_class.handle!(delivery_info,properties,payload)
+    end
+
+    it "should queue a resque job using JOB_KLASS and payload" do
+      expect(Resque).to have_received(:enqueue).with(MyTestJob,payload)
+    end
+
+    after do
+      ENV.delete("JOB_KLASS")
+    end
+  end
+end


### PR DESCRIPTION
# Problem

* Dead-letter exchange isn't configured by default, so failed handler execution isn't detected or accessible by default.
* Rabbit provides no concept of retry-10-times-then-fail
* Rabbit provides no way to easily re-try a job (at least not in the way Resque does)

# Solution

Defer all handling of messages to a resque job.  

This provides a handler that simply queues the payload to Resque.

Running on an internal app right now, without incident.