### PR TITLE
Specify a messsage_id for all published messages

### DIFF
--- a/lib/pwwka/transmitter.rb
+++ b/lib/pwwka/transmitter.rb
@@ -1,3 +1,5 @@
+require 'securerandom'
+
 begin  # optional dependency
   require 'resque'
 rescue LoadError
@@ -96,6 +98,7 @@ module Pwwka
       channel_connector.topic_exchange.publish(
           payload.to_json,
           routing_key: routing_key,
+          message_id: SecureRandom.uuid,
           persistent:  true)
       channel_connector.connection_close
       # if it gets this far it has succeeded

--- a/spec/transmitter_spec.rb
+++ b/spec/transmitter_spec.rb
@@ -45,6 +45,12 @@ describe Pwwka::Transmitter do
         delivery_info = @test_handler.pop_message.delivery_info
         expect(delivery_info.routing_key).to eq(routing_key)
       end
+
+      it "sets the message_id property" do
+        Pwwka::Transmitter.new.send_message!(payload, routing_key)
+        message = @test_handler.pop_message
+        expect(message.properties[:message_id]).to match(/[A-Z0-9]{8}-([A-Z0-9]{4}-){3}[A-Z0-9]{12}/i)
+      end
     end
 
     it "should blow up if exception raised" do


### PR DESCRIPTION
To allow for consumers to distinguish messages, it helps to provide a uniquely identifiable message id. This change updates the transmitter to set the `message_id` property on each published message to a uuid generated by `SecureRandom`.
