### PR TITLE
Log backtrace

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    pwwka (0.5.2)
+    pwwka (0.6.0)
       activemodel
       activesupport
       bunny
@@ -21,7 +21,7 @@ GEM
       tzinfo (~> 1.1)
     amq-protocol (2.0.1)
     builder (3.2.2)
-    bunny (2.3.0)
+    bunny (2.3.1)
       amq-protocol (>= 2.0.1)
     diff-lcs (1.2.5)
     i18n (0.7.0)
@@ -76,4 +76,4 @@ DEPENDENCIES
   rspec
 
 BUNDLED WITH
-   1.11.2
+   1.12.5

--- a/lib/pwwka/receiver.rb
+++ b/lib/pwwka/receiver.rb
@@ -29,7 +29,7 @@ module Pwwka
             receiver.ack(delivery_info.delivery_tag)
             logf "Processed Message on %{queue_name} -> %{payload}, %{routing_key}", queue_name: queue_name, payload: payload, routing_key: delivery_info.routing_key
           rescue => e
-            logf "Error Processing Message on %{queue_name} -> %{payload}, %{routing_key}: %{exception}", queue_name: queue_name, payload: payload, routing_key: delivery_info.routing_key, exception: e, at: :error
+            logf "Error Processing Message on %{queue_name} -> %{payload}, %{routing_key}: %{exception}: %{backtrace}", queue_name: queue_name, payload: payload, routing_key: delivery_info.routing_key, exception: e, backtrace: e.backtrace.join(';'), at: :error
             # no requeue
             receiver.nack(delivery_info.delivery_tag)
           end


### PR DESCRIPTION
# Problem

When we get an exception, we are only logging the message.  So, for exceptions that are somewhat generic like "Request Timeout", we can't figure out where it's coming from (and guess which exception we are randomly seeing a lot of today! :)

# Solution

Log the backtrace.