### PR TITLE
Configure pwwka for testing before all tests are run

### DIFF
--- a/lib/pwwka/test_handler.rb
+++ b/lib/pwwka/test_handler.rb
@@ -30,7 +30,7 @@ module Pwwka
                        end
     end
 
-    # Get the message on the queue as TestHandler::Message.
+    # Get the message on the queue as TestHandler::Message
     def pop_message
       delivery_info, properties, payload = test_queue.pop
       Message.new(delivery_info,
@@ -70,7 +70,7 @@ module Pwwka
         channel_connector.delayed_exchange.delete
       end
 
-      channel_connector.connection_close 
+      channel_connector.connection_close
     end
 
     # Simple class to hold a popped message.

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -10,7 +10,7 @@ RSpec.configure do |config|
     c.syntax = :expect
   end
 
-  config.before(:each) do
+  config.before(:all) do
     Pwwka.configure do |c|
       c.topic_exchange_name     = "topics-test"
       c.logger                  = MonoLogger.new("/dev/null")


### PR DESCRIPTION
To ensure tests are configured consistently, pwwka shouldbe configured
before all tests are run. Originally, running the full test suite would
pass, but running individual tests or spec files would cause intermittent
failures..