### PR TITLE
Option to nack-and-requeue messages exactly once

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    pwwka (0.8.0.RC1)
+    pwwka (0.8.0)
       activemodel
       activesupport
       bunny

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    pwwka (0.6.0)
+    pwwka (0.7.0.RC1)
       activemodel
       activesupport
       bunny
@@ -10,23 +10,20 @@ PATH
 GEM
   remote: https://www.rubygems.org/
   specs:
-    activemodel (4.2.6)
-      activesupport (= 4.2.6)
-      builder (~> 3.1)
-    activesupport (4.2.6)
+    activemodel (5.0.0.1)
+      activesupport (= 5.0.0.1)
+    activesupport (5.0.0.1)
+      concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (~> 0.7)
-      json (~> 1.7, >= 1.7.7)
       minitest (~> 5.1)
-      thread_safe (~> 0.3, >= 0.3.4)
       tzinfo (~> 1.1)
     amq-protocol (2.0.1)
-    builder (3.2.2)
-    bunny (2.3.1)
+    bunny (2.6.1)
       amq-protocol (>= 2.0.1)
+    concurrent-ruby (1.0.2)
     diff-lcs (1.2.5)
     i18n (0.7.0)
-    json (1.8.3)
-    minitest (5.8.4)
+    minitest (5.10.1)
     mono_logger (1.1.0)
     multi_json (1.11.2)
     rack (1.6.4)
@@ -76,4 +73,4 @@ DEPENDENCIES
   rspec
 
 BUNDLED WITH
-   1.12.5
+   1.13.6

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    pwwka (0.7.0.RC1)
+    pwwka (0.8.0.RC1)
       activemodel
       activesupport
       bunny

--- a/lib/pwwka/channel_connector.rb
+++ b/lib/pwwka/channel_connector.rb
@@ -26,14 +26,6 @@ module Pwwka
       @delayed_exchange ||= channel.fanout(configuration.delayed_exchange_name, durable: true)
     end
 
-    def dead_letter_exchange
-      @dead_letter_exchange ||= if configuration.dead_letter_exchange_name.nil?
-                                  nil
-                                else
-                                  channel.fanout(configuration.dead_letter_exchange_name, durable: true)
-                                end
-    end
-
     def delayed_queue
       # This works by hacking the dead letter exchange concept with a timeout.
       # We set up a delayed exchange that has a delayed queue.  This queue, configured below,

--- a/lib/pwwka/channel_connector.rb
+++ b/lib/pwwka/channel_connector.rb
@@ -26,6 +26,14 @@ module Pwwka
       @delayed_exchange ||= channel.fanout(configuration.delayed_exchange_name, durable: true)
     end
 
+    def dead_letter_exchange
+      @dead_letter_exchange ||= if configuration.dead_letter_exchange_name.nil?
+                                  nil
+                                else
+                                  channel.fanout(configuration.dead_letter_exchange_name, durable: true)
+                                end
+    end
+
     def delayed_queue
       # This works by hacking the dead letter exchange concept with a timeout.
       # We set up a delayed exchange that has a delayed queue.  This queue, configured below,

--- a/lib/pwwka/configuration.rb
+++ b/lib/pwwka/configuration.rb
@@ -10,6 +10,7 @@ module Pwwka
     attr_accessor :logger
     attr_accessor :options
     attr_accessor :send_message_resque_backoff_strategy
+    attr_accessor :requeue_on_error
 
     def initialize
       @rabbit_mq_host        = nil
@@ -20,6 +21,7 @@ module Pwwka
       @send_message_resque_backoff_strategy = [5,                  #intermittent glitch?
                                                60,                 # quick interruption
                                                600, 600, 600] # longer-term outage?
+      @requeue_on_error = false
     end
 
     def payload_logging

--- a/lib/pwwka/configuration.rb
+++ b/lib/pwwka/configuration.rb
@@ -11,6 +11,7 @@ module Pwwka
     attr_accessor :options
     attr_accessor :send_message_resque_backoff_strategy
     attr_accessor :requeue_on_error
+    attr_accessor :dead_letter_exchange_name
 
     def initialize
       @rabbit_mq_host        = nil
@@ -22,6 +23,7 @@ module Pwwka
                                                60,                 # quick interruption
                                                600, 600, 600] # longer-term outage?
       @requeue_on_error = false
+      @dead_letter_exchange_name = nil
     end
 
     def payload_logging

--- a/lib/pwwka/configuration.rb
+++ b/lib/pwwka/configuration.rb
@@ -11,7 +11,6 @@ module Pwwka
     attr_accessor :options
     attr_accessor :send_message_resque_backoff_strategy
     attr_accessor :requeue_on_error
-    attr_accessor :dead_letter_exchange_name
 
     def initialize
       @rabbit_mq_host        = nil
@@ -23,7 +22,6 @@ module Pwwka
                                                60,                 # quick interruption
                                                600, 600, 600] # longer-term outage?
       @requeue_on_error = false
-      @dead_letter_exchange_name = nil
     end
 
     def payload_logging

--- a/lib/pwwka/receiver.rb
+++ b/lib/pwwka/receiver.rb
@@ -48,12 +48,7 @@ module Pwwka
 
     def topic_queue
       @topic_queue ||= begin
-        arguments = if channel_connector.dead_letter_exchange.nil?
-                      {}
-                    else
-                      { "x-dead-letter-exchange" => channel_connector.dead_letter_exchange.name }
-                    end
-        queue = channel.queue(queue_name, durable: true, arguments: arguments)
+        queue = channel.queue(queue_name, durable: true, arguments: {})
         queue.bind(topic_exchange, routing_key: routing_key)
         queue
       end

--- a/lib/pwwka/version.rb
+++ b/lib/pwwka/version.rb
@@ -1,3 +1,3 @@
 module Pwwka
-  VERSION = '0.6.0'
+  VERSION = '0.7.0.RC1'
 end

--- a/lib/pwwka/version.rb
+++ b/lib/pwwka/version.rb
@@ -1,3 +1,3 @@
 module Pwwka
-  VERSION = '0.8.0.RC1'
+  VERSION = '0.8.0'
 end

--- a/lib/pwwka/version.rb
+++ b/lib/pwwka/version.rb
@@ -1,3 +1,3 @@
 module Pwwka
-  VERSION = '0.7.0.RC1'
+  VERSION = '0.8.0.RC1'
 end


### PR DESCRIPTION
# Problem

When a message hander fails, we reject it with no retry.  This means that the message is dropped on the floor and the only way to retry it is to find the payload in the log and execute it manually in console.

# Solution

As a simple thing to try, this allows configuration of pwwka so that a message is retried exactly once.  It does this by checking if the message has been retried.  If so, it does what it does now, but if not, it nacks it and requeues it.

In theory, this should allow us to recover from intermittent issues, but not get into an infinite loop on hard failures.

## What about the DLX?

There's no straightforward way to manage stuff in the DLX, so that is something we can look into later.