### PR TITLE
crash receiver on all errors

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    pwwka (0.9.0.RC1)
+    pwwka (0.8.0)
       activemodel
       activesupport
       bunny
@@ -17,8 +17,8 @@ GEM
       i18n (~> 0.7)
       minitest (~> 5.1)
       tzinfo (~> 1.1)
-    amq-protocol (2.0.1)
-    bunny (2.6.2)
+    amq-protocol (2.1.0)
+    bunny (2.6.3)
       amq-protocol (>= 2.0.1)
     concurrent-ruby (1.0.4)
     diff-lcs (1.2.5)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    pwwka (0.8.0)
+    pwwka (0.9.0.RC1)
       activemodel
       activesupport
       bunny
@@ -10,20 +10,20 @@ PATH
 GEM
   remote: https://www.rubygems.org/
   specs:
-    activemodel (5.0.0.1)
-      activesupport (= 5.0.0.1)
-    activesupport (5.0.0.1)
+    activemodel (5.0.1)
+      activesupport (= 5.0.1)
+    activesupport (5.0.1)
       concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (~> 0.7)
       minitest (~> 5.1)
       tzinfo (~> 1.1)
     amq-protocol (2.0.1)
-    bunny (2.6.1)
+    bunny (2.6.2)
       amq-protocol (>= 2.0.1)
-    concurrent-ruby (1.0.2)
+    concurrent-ruby (1.0.4)
     diff-lcs (1.2.5)
     docile (1.1.5)
-    i18n (0.7.0)
+    i18n (0.8.0)
     json (1.8.3)
     minitest (5.10.1)
     mono_logger (1.1.0)

--- a/lib/pwwka/configuration.rb
+++ b/lib/pwwka/configuration.rb
@@ -11,6 +11,7 @@ module Pwwka
     attr_accessor :options
     attr_accessor :send_message_resque_backoff_strategy
     attr_accessor :requeue_on_error
+    attr_writer   :keep_alive_on_handler_klass_exceptions
 
     def initialize
       @rabbit_mq_host        = nil
@@ -22,6 +23,11 @@ module Pwwka
                                                60,                 # quick interruption
                                                600, 600, 600] # longer-term outage?
       @requeue_on_error = false
+      @keep_alive_on_handler_klass_exceptions = false
+    end
+
+    def keep_alive_on_handler_klass_exceptions?
+      @keep_alive_on_handler_klass_exceptions
     end
 
     def payload_logging

--- a/lib/pwwka/version.rb
+++ b/lib/pwwka/version.rb
@@ -1,3 +1,3 @@
 module Pwwka
-  VERSION = '0.9.0.RC1'
+  VERSION = '0.8.0'
 end

--- a/lib/pwwka/version.rb
+++ b/lib/pwwka/version.rb
@@ -1,3 +1,3 @@
 module Pwwka
-  VERSION = '0.8.0'
+  VERSION = '0.9.0.RC1'
 end

--- a/spec/integration/support/logging_receiver.rb
+++ b/spec/integration/support/logging_receiver.rb
@@ -1,6 +1,6 @@
 class LoggingReceiver
   def self.reset!; @messages_received = []; end
-  def self.messages_received; @messages_received; end
+  def self.messages_received; @messages_received ||= []; end
 
   reset!
 

--- a/spec/integration/unhandled_errors_in_receivers_spec.rb
+++ b/spec/integration/unhandled_errors_in_receivers_spec.rb
@@ -11,12 +11,14 @@ describe "receivers with unhandled errors", :integration do
     setup_receivers
     Pwwka.configure do |c|
       c.requeue_on_error = false
+      c.keep_alive_on_handler_klass_exceptions = false
     end
   end
 
   before :each do
     WellBehavedReceiver.reset!
     ExceptionThrowingReceiver.reset!
+    IntermittentErrorReceiver.reset!
   end
 
   after do
@@ -35,6 +37,7 @@ describe "receivers with unhandled errors", :integration do
   it "when configured to requeue failed messages, the message is requeued exactly once" do
     Pwwka.configure do |c|
       c.requeue_on_error = true
+      c.keep_alive_on_handler_klass_exceptions = true # only so we can check that the requeued message got sent; otherwise the receiver crashes and we can't test that
     end
     Pwwka::Transmitter.send_message!({ sample: "payload", has: { deeply: true, nested: 4 }},
                                      "pwwka.testing.foo")
@@ -46,18 +49,65 @@ describe "receivers with unhandled errors", :integration do
     expect(ExceptionThrowingReceiver.messages_received[1][2]).to eq(ExceptionThrowingReceiver.messages_received[0][2])
   end
 
+  it "crashes the receiver that received an error" do
+    Pwwka::Transmitter.send_message!({ sample: "payload", has: { deeply: true, nested: 4 }},
+                                     "pwwka.testing.foo")
+    allow_receivers_to_process_queues
+
+    expect(@testing_setup.threads[ExceptionThrowingReceiver].alive?).to eq(false)
+  end
+
+  it "does not crash the receiver that received an error when we configure it not to" do
+    Pwwka.configure do |c|
+      c.keep_alive_on_handler_klass_exceptions = true
+    end
+    Pwwka::Transmitter.send_message!({ sample: "payload", has: { deeply: true, nested: 4 }},
+                                     "pwwka.testing.foo")
+    allow_receivers_to_process_queues
+
+    expect(@testing_setup.threads[ExceptionThrowingReceiver].alive?).to eq(true)
+  end
+
+  it "does not crash the receiver that successfully processed a message" do
+    Pwwka::Transmitter.send_message!({ sample: "payload", has: { deeply: true, nested: 4 }},
+                                     "pwwka.testing.foo")
+    allow_receivers_to_process_queues
+
+    expect(@testing_setup.threads[WellBehavedReceiver].alive?).to  eq(true)
+  end
+
+  it "crashes the receiver if it gets a failure that we retry" do
+    Pwwka.configure do |c|
+      c.requeue_on_error = true
+    end
+    Pwwka::Transmitter.send_message!({ sample: "payload", has: { deeply: true, nested: 4 }},
+                                     "pwwka.testing.foo")
+    allow_receivers_to_process_queues
+
+    expect(@testing_setup.threads[IntermittentErrorReceiver].alive?).to eq(false)
+  end
+
   def setup_receivers
     [
       [ExceptionThrowingReceiver, "exception_throwing_receiver_pwwkatesting"],
       [WellBehavedReceiver, "well_behaved_receiver_pwwkatesting"],
+      [IntermittentErrorReceiver, "intermittent_error_receiver_pwwkatesting"],
     ].each do |(klass, queue_name)|
       @testing_setup.make_queue_and_setup_receiver(klass,queue_name,"#")
     end
   end
   class ExceptionThrowingReceiver < LoggingReceiver
     def self.handle!(delivery_info,properties,payload)
-      super.handle!(delivery_info,properties,payload)
+      super(delivery_info,properties,payload)
       raise "OH NOES!"
+    end
+  end
+  class IntermittentErrorReceiver < LoggingReceiver
+    def self.handle!(delivery_info,properties,payload)
+      super(delivery_info,properties,payload)
+      unless delivery_info.redelivered
+        raise "OH NOES!"
+      end
     end
   end
   class WellBehavedReceiver < LoggingReceiver


### PR DESCRIPTION
# Problem

A handler can experience a hard, unrecoverable failure that is often fixed by restarting.  An example is if a database connection goes bad.  In a typical process-based-concurrency setup, like Rails and Resque, each request starts in a fresh process and we can reset things.  The Pwwka Receiver doesn't work this way—it runs forever.  This means it can be stuck in a forever failing state.

# Solution

Crash on all errors.  Letting processes crash is generally good advice .  It's how Erlang does things and is generally  better than piecemeal handling of errors.  See http://stackoverflow.com/questions/4393197/erlangs-let-it-crash-philosophy-applicable-elsewhere and http://web.archive.org/web/20090430014122/http://nplus1.org/articles/a-crash-course-in-failure/

## Notes

This includes a backdoor configuration to *not* do this, but this behavior is being added as the default.  Since your existing deployments have to handle crashes anyway, this should not really change things, however I could see how it's a breaking change.  I think I'm OK with that and maybe this is now time for 1.x, but since we are in 0.x land, maybe it's fine to keep going.