### PR TITLE
Revert activesupport bump to 5.0 to preserve backwards compatibility

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,29 +2,31 @@ PATH
   remote: .
   specs:
     pwwka (0.8.0)
-      activemodel
-      activesupport
+      activemodel (~> 4.2)
+      activesupport (~> 4.2)
       bunny
       mono_logger
 
 GEM
   remote: https://www.rubygems.org/
   specs:
-    activemodel (5.0.0.1)
-      activesupport (= 5.0.0.1)
-    activesupport (5.0.0.1)
-      concurrent-ruby (~> 1.0, >= 1.0.2)
+    activemodel (4.2.7.1)
+      activesupport (= 4.2.7.1)
+      builder (~> 3.1)
+    activesupport (4.2.7.1)
       i18n (~> 0.7)
+      json (~> 1.7, >= 1.7.7)
       minitest (~> 5.1)
+      thread_safe (~> 0.3, >= 0.3.4)
       tzinfo (~> 1.1)
     amq-protocol (2.0.1)
-    bunny (2.6.1)
+    builder (3.2.3)
+    bunny (2.6.2)
       amq-protocol (>= 2.0.1)
-    concurrent-ruby (1.0.2)
     diff-lcs (1.2.5)
     docile (1.1.5)
     i18n (0.7.0)
-    json (1.8.3)
+    json (1.8.6)
     minitest (5.10.1)
     mono_logger (1.1.0)
     multi_json (1.11.2)
@@ -95,4 +97,4 @@ DEPENDENCIES
   simplecov
 
 BUNDLED WITH
-   1.13.6
+   1.13.7

--- a/pwwka.gemspec
+++ b/pwwka.gemspec
@@ -20,8 +20,8 @@ Gem::Specification.new do |s|
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   s.require_paths = ["lib"]
   s.add_runtime_dependency("bunny")
-  s.add_runtime_dependency("activesupport")
-  s.add_runtime_dependency("activemodel")
+  s.add_runtime_dependency("activesupport", "~> 4.2")
+  s.add_runtime_dependency("activemodel", "~> 4.2")
   s.add_runtime_dependency("mono_logger")
   s.add_development_dependency("rake")
   s.add_development_dependency("rspec")


### PR DESCRIPTION
I attempted to upgrade to the latest Pwwka gem version today to take advantage of the `requeue_on_error ` config option, but was unable to since the Active* gems in this project had been bumped to 5.0 and my Rails project was on 4.2. Since I would expect this to represent a major version bump of the gem itself, I thought it may have been unintentional.

If you agree with the above, here is a patch to downgrade the Active* gems to the 4.2 stable versions.

Thanks!