### PR TITLE
Add a config setting to change the async job queue

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    pwwka (0.9.0)
+    pwwka (0.10.0.RC)
       activemodel
       activesupport
       bunny

--- a/README.md
+++ b/README.md
@@ -133,12 +133,20 @@ To enqueue a message in a background Resque job, use `Transmitter.send_message_a
 Pwwka::Transmitter.send_message_async(payload, routing_key, delay_by_ms: 5000) # default delay is 0
 ```
 
-If `Resque::Plugins::ExponentialBackoff` is available, the job will use it.
+If `Resque::Plugins::ExponentialBackoff` is available, the job will use it. (Important: Your load/require order is important if you want exponential backoff with the built-in job due [its error handling](https://github.com/stitchfix/pwwka/blob/713c6003fa6cf52cb4713c02b39fe7ee07ebe2e9/lib/pwwka/send_message_async_job.rb#L8).)
 Customize the backoff intervals using the configuration `send_message_resque_backoff_strategy`.
 The default backoff will retry quickly in case of an intermittent glitch, and then every ten 
 minutes for half an hour.
 
 The name of the queue created is `pwwka_send_message_async`.
+
+You can configure Pwwka to use your own custom job using the `async_job_klass` configuration option. Example might be:
+
+```
+Pwwka.configure do |config|
+  config.async_job_klass = YourApp::PwwkaAsyncJob
+end
+```
 
 #### Message Queuer
 

--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ To enqueue a message in a background Resque job, use `Transmitter.send_message_a
 Pwwka::Transmitter.send_message_async(payload, routing_key, delay_by_ms: 5000) # default delay is 0
 ```
 
-If `Resque::Plugins::ExponentialBackoff` is available, the job will use it. (Important: Your load/require order is important if you want exponential backoff with the built-in job due [its error handling](https://github.com/stitchfix/pwwka/blob/713c6003fa6cf52cb4713c02b39fe7ee07ebe2e9/lib/pwwka/send_message_async_job.rb#L8).)
+If `Resque::Plugins::ExponentialBackoff` is available, the job will use it. (Important: Your load/require order is important if you want exponential backoff with the built-in job due to [its error handling](https://github.com/stitchfix/pwwka/blob/713c6003fa6cf52cb4713c02b39fe7ee07ebe2e9/lib/pwwka/send_message_async_job.rb#L8).)
 Customize the backoff intervals using the configuration `send_message_resque_backoff_strategy`.
 The default backoff will retry quickly in case of an intermittent glitch, and then every ten 
 minutes for half an hour.

--- a/lib/pwwka/configuration.rb
+++ b/lib/pwwka/configuration.rb
@@ -9,7 +9,7 @@ module Pwwka
     attr_accessor :delayed_exchange_name
     attr_accessor :logger
     attr_accessor :options
-    attr_accessor :send_message_async_job
+    attr_accessor :async_job_klass
     attr_accessor :send_message_resque_backoff_strategy
     attr_accessor :requeue_on_error
     attr_writer   :keep_alive_on_handler_klass_exceptions
@@ -25,7 +25,7 @@ module Pwwka
                                                600, 600, 600] # longer-term outage?
       @requeue_on_error = false
       @keep_alive_on_handler_klass_exceptions = false
-      @send_message_async_job = Pwwka::SendMessageAsyncJob
+      @async_job_klass = Pwwka::SendMessageAsyncJob
     end
 
     def keep_alive_on_handler_klass_exceptions?

--- a/lib/pwwka/configuration.rb
+++ b/lib/pwwka/configuration.rb
@@ -9,6 +9,7 @@ module Pwwka
     attr_accessor :delayed_exchange_name
     attr_accessor :logger
     attr_accessor :options
+    attr_accessor :send_message_async_job
     attr_accessor :send_message_resque_backoff_strategy
     attr_accessor :requeue_on_error
     attr_writer   :keep_alive_on_handler_klass_exceptions
@@ -24,6 +25,7 @@ module Pwwka
                                                600, 600, 600] # longer-term outage?
       @requeue_on_error = false
       @keep_alive_on_handler_klass_exceptions = false
+      @send_message_async_job = Pwwka::SendMessageAsyncJob
     end
 
     def keep_alive_on_handler_klass_exceptions?

--- a/lib/pwwka/transmitter.rb
+++ b/lib/pwwka/transmitter.rb
@@ -75,7 +75,7 @@ module Pwwka
     # Use Resque to enqueue the message.
     # - :delay_by_ms:: Integer milliseconds to delay the message. Default is 0.
     def self.send_message_async(payload, routing_key, delay_by_ms: 0)
-      job = Pwwka.configuration.send_message_async_job
+      job = Pwwka.configuration.async_job_klass
       Resque.enqueue_in(delay_by_ms/1000, job, payload, routing_key)
     end
 

--- a/lib/pwwka/transmitter.rb
+++ b/lib/pwwka/transmitter.rb
@@ -75,7 +75,8 @@ module Pwwka
     # Use Resque to enqueue the message.
     # - :delay_by_ms:: Integer milliseconds to delay the message. Default is 0.
     def self.send_message_async(payload, routing_key, delay_by_ms: 0)
-      Resque.enqueue_in(delay_by_ms/1000, SendMessageAsyncJob, payload, routing_key)
+      job = Pwwka.configuration.send_message_async_job
+      Resque.enqueue_in(delay_by_ms/1000, job, payload, routing_key)
     end
 
     # Send a less important message that doesn't have to go through. This eats

--- a/lib/pwwka/version.rb
+++ b/lib/pwwka/version.rb
@@ -1,3 +1,3 @@
 module Pwwka
-  VERSION = '0.9.0'
+  VERSION = '0.10.0.RC'
 end

--- a/spec/integration/send_and_receive_spec.rb
+++ b/spec/integration/send_and_receive_spec.rb
@@ -90,9 +90,9 @@ describe "sending and receiving messages", :integration do
   end
 
   it "can queue a job to send a message to a specified Resque job queue" do
-    send_message_async_job = double(:send_message_async_job)
+    async_job_klass = double(:async_job_klass)
     configuration = Pwwka::Configuration.new
-    configuration.send_message_async_job = send_message_async_job
+    configuration.async_job_klass = async_job_klass
 
     allow(Pwwka).to receive(:configuration).and_return(configuration)
 
@@ -101,7 +101,7 @@ describe "sending and receiving messages", :integration do
     Pwwka::Transmitter.send_message_async({ sample: "payload", has: { deeply: true, nested: 4 }},
                                           "pwwka.testing.bar")
 
-    expect(Resque).to have_received(:enqueue_in).with(anything, send_message_async_job, anything, anything)
+    expect(Resque).to have_received(:enqueue_in).with(anything, async_job_klass, anything, anything)
   end
 
   class AllReceiver < LoggingReceiver

--- a/spec/integration/send_and_receive_spec.rb
+++ b/spec/integration/send_and_receive_spec.rb
@@ -89,6 +89,21 @@ describe "sending and receiving messages", :integration do
     expect(AllReceiver.messages_received.size).to eq(1)
   end
 
+  it "can queue a job to send a message to a specified Resque job queue" do
+    send_message_async_job = double(:send_message_async_job)
+    configuration = Pwwka::Configuration.new
+    configuration.send_message_async_job = send_message_async_job
+
+    allow(Pwwka).to receive(:configuration).and_return(configuration)
+
+    allow(Resque).to receive(:enqueue_in)
+
+    Pwwka::Transmitter.send_message_async({ sample: "payload", has: { deeply: true, nested: 4 }},
+                                          "pwwka.testing.bar")
+
+    expect(Resque).to have_received(:enqueue_in).with(anything, send_message_async_job, anything, anything)
+  end
+
   class AllReceiver < LoggingReceiver
   end
   class FooReceiver < AllReceiver


### PR DESCRIPTION
# Problem

[SendMessageAsyncJob requires resque-retry](https://github.com/stitchfix/pwwka/blob/713c6003fa6cf52cb4713c02b39fe7ee07ebe2e9/lib/pwwka/send_message_async_job.rb#L8) to already be loaded in order for any retries to happen. Because of this, you likely need to `require: false` this gem and then explicitly require it after `resque-retry` is loaded.

Pwwka users may want to create their own Resque job to process asynchronously sent messages.

# Solution
Add a config variable `send_message_async_job` and use it to set the Resque job class.