### PR TITLE
pass more info to Resque jobs, if configured

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    pwwka (0.10.0)
+    pwwka (0.11.0.RC1)
       activemodel
       activesupport
       bunny
@@ -10,9 +10,9 @@ PATH
 GEM
   remote: https://www.rubygems.org/
   specs:
-    activemodel (5.1.1)
-      activesupport (= 5.1.1)
-    activesupport (5.1.1)
+    activemodel (5.1.3)
+      activesupport (= 5.1.3)
+    activesupport (5.1.3)
       concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (~> 0.7)
       minitest (~> 5.1)
@@ -25,9 +25,9 @@ GEM
     docile (1.1.5)
     et-orbi (1.0.4)
       tzinfo
-    i18n (0.8.1)
+    i18n (0.8.6)
     json (2.1.0)
-    minitest (5.10.2)
+    minitest (5.10.3)
     mono_logger (1.1.0)
     multi_json (1.12.1)
     mustermann (1.0.0)
@@ -102,4 +102,4 @@ DEPENDENCIES
   simplecov
 
 BUNDLED WITH
-   1.14.6
+   1.15.4

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    pwwka (0.12.0.RC1)
+    pwwka (0.12.0.RC2)
       activemodel
       activesupport
       bunny

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    pwwka (0.11.0.RC1)
+    pwwka (0.12.0.RC1)
       activemodel
       activesupport
       bunny

--- a/README.md
+++ b/README.md
@@ -322,7 +322,7 @@ If you use [Resque][resque], and you wish to handle messages in a resque job, yo
 
    Note that you must provide `@queue` in your job.  `QueueResqueJobHandler` doesn't support setting a custom queue at enqueue-time (PRs welcome :).
 
-   Note that if you were using this library before version 0.11.0, your job would only be given the payload.  This is why `PWWKA_QUEUE_EXTENDED_INFO` must be set.  Without it, your job only gets the payload to avoid breaking legacy consumers.  You should always set this so you have access to the entire message.
+   Note that if you were using this library before version 0.12.0, your job would only be given the payload.  This is why `PWWKA_QUEUE_EXTENDED_INFO` must be set.  Without it, your job only gets the payload to avoid breaking legacy consumers.  You should always set this so you have access to the entire message.
 3. Profit!
 
 [resque]: https://github.com/resque/resque/tree/1-x-stable

--- a/README.md
+++ b/README.md
@@ -301,7 +301,7 @@ If you use [Resque][resque], and you wish to handle messages in a resque job, yo
 2. Now, configure your handler.  For a `Procfile` setup:
 
    ```
-   my_handler: rake message_handler:receive HANDLER_KLASS=Pwwka::QueueResqueJobHandler JOB_KLASS=MyResqueJob PWWKA_QUEUE_EXTENDED_INFO=true QUEUE_NAME=my_queue ROUTING_KEY="my.key.completed"
+   my_handler: rake message_handler:receive HANDLER_KLASS=Pwwka::QueueResqueJobHandler JOB_KLASS=MyResqueJob QUEUE_NAME=my_queue ROUTING_KEY="my.key.completed"
    ```
 
    Note the use of the environment variable `JOB_KLASS`.  This tells `QueueResqueJobHandler` which class to queue.
@@ -322,7 +322,8 @@ If you use [Resque][resque], and you wish to handle messages in a resque job, yo
 
    Note that you must provide `@queue` in your job.  `QueueResqueJobHandler` doesn't support setting a custom queue at enqueue-time (PRs welcome :).
 
-   Note that if you were using this library before version 0.12.0, your job would only be given the payload.  This is why `PWWKA_QUEUE_EXTENDED_INFO` must be set.  Without it, your job only gets the payload to avoid breaking legacy consumers.  You should always set this so you have access to the entire message.
+   Note that if you were using this library before version 0.12.0, your job would only be given the payload.  If you change your job to accept exatly three arguments, you will be given the payload, routing key, and message properties.  If any of those arguments are optional, you will need to set `PWWKA_QUEUE_EXTENDED_INFO` to `"true"` to force pwwka to pass those along.  Without it, your job only gets the payload to avoid breaking legacy consumers. 
+
 3. Profit!
 
 [resque]: https://github.com/resque/resque/tree/1-x-stable

--- a/lib/pwwka/queue_resque_job_handler.rb
+++ b/lib/pwwka/queue_resque_job_handler.rb
@@ -4,16 +4,26 @@ require 'resque'
 module Pwwka
   # A handler that simply queues the payload into a Resque job.  This is useful
   # if the code that should respond to a message needs to be managed by Resque, e.g.
-  # for the purposes of retry or better failure management.
+  # for the purposes of retry or better failure management.  You can ask for the routing key and properties
+  # by setting `PWWKA_QUEUE_EXTENDED_INFO` to `true` in your environment.
   #
   # You should be able to use this directly from your handler configuration, e.g. for a Heroku-style `Procfile`:
   #
   #     my_handler: rake message_handler:receive HANDLER_KLASS=Pwwka::QueueResqueJobHandler JOB_KLASS=MyResqueJob QUEUE_NAME=my_queue ROUTING_KEY="my.key.completed"
+  #     my_handler_that_wants_more_info: rake message_handler:receive HANDLER_KLASS=Pwwka::QueueResqueJobHandler JOB_KLASS=MyOthgerResqueJob PWWKA_QUEUE_EXTENDED_INFO=true QUEUE_NAME=my_queue ROUTING_KEY="my.key.#"
   #
   # Note that this will not check the routing key, so you should be sure to specify the most precise ROUTING_KEY you can for handling the message.
   class QueueResqueJobHandler
     def self.handle!(delivery_info,properties,payload)
-      Resque.enqueue(ENV["JOB_KLASS"].constantize, payload)
+      args = [
+        ENV["JOB_KLASS"].constantize,
+        payload
+      ]
+      if ENV["PWWKA_QUEUE_EXTENDED_INFO"] == 'true'
+        args << delivery_info.routing_key
+        args << properties.to_hash
+      end
+      Resque.enqueue(*args)
     end
   end
 end

--- a/lib/pwwka/version.rb
+++ b/lib/pwwka/version.rb
@@ -1,3 +1,3 @@
 module Pwwka
-  VERSION = '0.10.0'
+  VERSION = '0.11.0.RC1'
 end

--- a/lib/pwwka/version.rb
+++ b/lib/pwwka/version.rb
@@ -1,3 +1,3 @@
 module Pwwka
-  VERSION = '0.11.0.RC1'
+  VERSION = '0.12.0.RC1'
 end

--- a/lib/pwwka/version.rb
+++ b/lib/pwwka/version.rb
@@ -1,3 +1,3 @@
 module Pwwka
-  VERSION = '0.12.0.RC1'
+  VERSION = '0.12.0.RC2'
 end

--- a/spec/integration/send_and_receive_spec.rb
+++ b/spec/integration/send_and_receive_spec.rb
@@ -35,7 +35,7 @@ describe "sending and receiving messages", :integration do
   after do
     @testing_setup.kill_threads_and_clear_queues
     ENV.delete("JOB_KLASS")
-    ENV.delette("PWWKA_QUEUE_EXTENDED_INFO")
+    ENV.delete("PWWKA_QUEUE_EXTENDED_INFO")
   end
 
   context "routing" do

--- a/spec/integration/send_and_receive_spec.rb
+++ b/spec/integration/send_and_receive_spec.rb
@@ -34,6 +34,8 @@ describe "sending and receiving messages", :integration do
 
   after do
     @testing_setup.kill_threads_and_clear_queues
+    ENV.delete("JOB_KLASS")
+    ENV.delette("PWWKA_QUEUE_EXTENDED_INFO")
   end
 
   context "routing" do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -46,8 +46,7 @@ RSpec.configure do |config|
     if example.metadata[:integration]
       result = test_configuration.check_services
       unless result.up?
-        puts "\n\n" + Rainbow(result.error).yellow.bright + "\n\n"
-        exit 1
+        fail result.error
       end
     end
     example.run

--- a/spec/unit/queue_resque_job_handler_spec.rb
+++ b/spec/unit/queue_resque_job_handler_spec.rb
@@ -8,8 +8,16 @@ describe Pwwka::QueueResqueJobHandler do
 
   describe "::handle!" do
     let(:job_class) { MyTestJob }
-    let(:delivery_info) { double("delivery info") }
-    let(:properties) { double("properties") }
+    let(:routing_key) { "foo.bar.blah" }
+    let(:delivery_info) { double("delivery info", routing_key: routing_key) }
+    let(:properties_hash) {
+      {
+        "app_id" => "myapp",
+        "timestamp" => "2015-12-12 13:22:99",
+        "message_id" => "66",
+      }
+    }
+    let(:properties) { Bunny::MessageProperties.new(properties_hash) }
     let(:payload) {
       {
         "this" => "is",
@@ -21,16 +29,34 @@ describe Pwwka::QueueResqueJobHandler do
     before do
       allow(Resque).to receive(:enqueue)
       ENV["JOB_KLASS"] = MyTestJob.name
-
-      described_class.handle!(delivery_info,properties,payload)
     end
 
-    it "should queue a resque job using JOB_KLASS and payload" do
-      expect(Resque).to have_received(:enqueue).with(MyTestJob,payload)
+    context "when not asking for more information explicitly" do
+      it "should queue a resque job using JOB_KLASS and the payload" do
+        described_class.handle!(delivery_info,properties,payload)
+        expect(Resque).to have_received(:enqueue).with(MyTestJob,payload)
+      end
+    end
+
+    context "when asking to NOT receive more information explicitly" do
+      it "should queue a resque job using JOB_KLASS and the payload" do
+        ENV["PWWKA_QUEUE_EXTENDED_INFO"] = 'false'
+        described_class.handle!(delivery_info,properties,payload)
+        expect(Resque).to have_received(:enqueue).with(MyTestJob,payload)
+      end
+    end
+
+    context "when asking for more information via PWWKA_QUEUE_EXTENDED_INFO" do
+      it "should queue a resque job using JOB_KLASS, payload, routing key, and properties as a hash" do
+        ENV["PWWKA_QUEUE_EXTENDED_INFO"] = 'true'
+        described_class.handle!(delivery_info,properties,payload)
+        expect(Resque).to have_received(:enqueue).with(MyTestJob,payload,routing_key,properties_hash)
+      end
     end
 
     after do
       ENV.delete("JOB_KLASS")
+      ENV.delete("PWWKA_QUEUE_EXTENDED_INFO")
     end
   end
 end

--- a/spec/unit/queue_resque_job_handler_spec.rb
+++ b/spec/unit/queue_resque_job_handler_spec.rb
@@ -1,13 +1,20 @@
 require 'spec_helper'
 require 'pwwka/queue_resque_job_handler'
 
-class MyTestJob
+class MyLegacyTestJob
+  def self.perform(payload)
+  end
+end
+
+class MyNewTestJob
+  def self.perform(payload, routing_key, properties)
+  end
 end
 
 describe Pwwka::QueueResqueJobHandler do
 
   describe "::handle!" do
-    let(:job_class) { MyTestJob }
+    let(:job_class) { MyLegacyTestJob }
     let(:routing_key) { "foo.bar.blah" }
     let(:delivery_info) { double("delivery info", routing_key: routing_key) }
     let(:properties_hash) {
@@ -28,13 +35,13 @@ describe Pwwka::QueueResqueJobHandler do
 
     before do
       allow(Resque).to receive(:enqueue)
-      ENV["JOB_KLASS"] = MyTestJob.name
+      ENV["JOB_KLASS"] = MyLegacyTestJob.name
     end
 
     context "when not asking for more information explicitly" do
       it "should queue a resque job using JOB_KLASS and the payload" do
         described_class.handle!(delivery_info,properties,payload)
-        expect(Resque).to have_received(:enqueue).with(MyTestJob,payload)
+        expect(Resque).to have_received(:enqueue).with(MyLegacyTestJob,payload)
       end
     end
 
@@ -42,15 +49,26 @@ describe Pwwka::QueueResqueJobHandler do
       it "should queue a resque job using JOB_KLASS and the payload" do
         ENV["PWWKA_QUEUE_EXTENDED_INFO"] = 'false'
         described_class.handle!(delivery_info,properties,payload)
-        expect(Resque).to have_received(:enqueue).with(MyTestJob,payload)
+        expect(Resque).to have_received(:enqueue).with(MyLegacyTestJob,payload)
       end
     end
 
     context "when asking for more information via PWWKA_QUEUE_EXTENDED_INFO" do
       it "should queue a resque job using JOB_KLASS, payload, routing key, and properties as a hash" do
+        # Note, using MyLegacyTestJob to ensure this doesn't trigger the method param examination logic and respects
+        # the env var, even though it is not used correctly in this case.
         ENV["PWWKA_QUEUE_EXTENDED_INFO"] = 'true'
         described_class.handle!(delivery_info,properties,payload)
-        expect(Resque).to have_received(:enqueue).with(MyTestJob,payload,routing_key,properties_hash)
+        expect(Resque).to have_received(:enqueue).with(MyLegacyTestJob,payload,routing_key,properties_hash)
+      end
+    end
+
+    context "when not asking for more information via PWWKA_QUEUE_EXTENDED_INFO but for a job that can handle it" do
+      it "should queue a resque job using JOB_KLASS, payload, routing key, and properties as a hash" do
+        ENV["JOB_KLASS"] = MyNewTestJob.name
+        ENV.delete("PWWKA_QUEUE_EXTENDED_INFO")
+        described_class.handle!(delivery_info,properties,payload)
+        expect(Resque).to have_received(:enqueue).with(MyNewTestJob,payload,routing_key,properties_hash)
       end
     end
 


### PR DESCRIPTION
# Problem

When using the `QueueResqueJobHandler`, the routing key and message properties are not passed along.  This is useful information  and should be passed.

# Solution

Pass it for anyone opting-in to receive those (so as to not break legacy job classes)