### PR TITLE
Flexible and extensible error handling

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    pwwka (0.13.0.RC1)
+    pwwka (0.13.0.RC2)
       activemodel
       activesupport
       bunny

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    pwwka (0.12.0)
+    pwwka (0.13.0.RC1)
       activemodel
       activesupport
       bunny
@@ -10,9 +10,9 @@ PATH
 GEM
   remote: https://www.rubygems.org/
   specs:
-    activemodel (5.1.3)
-      activesupport (= 5.1.3)
-    activesupport (5.1.3)
+    activemodel (5.1.4)
+      activesupport (= 5.1.4)
+    activesupport (5.1.4)
       concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (~> 0.7)
       minitest (~> 5.1)

--- a/lib/pwwka.rb
+++ b/lib/pwwka.rb
@@ -28,7 +28,7 @@ require 'pwwka/handling'
 require 'pwwka/receiver'
 require 'pwwka/transmitter'
 require 'pwwka/message_queuer'
+require 'pwwka/error_handlers'
 require 'pwwka/configuration'
 require 'pwwka/send_message_async_job'
-
 

--- a/lib/pwwka/configuration.rb
+++ b/lib/pwwka/configuration.rb
@@ -11,9 +11,18 @@ module Pwwka
     attr_accessor :options
     attr_accessor :async_job_klass
     attr_accessor :send_message_resque_backoff_strategy
-    attr_accessor :requeue_on_error
+    attr_reader   :requeue_on_error
     attr_writer   :app_id
-    attr_writer   :keep_alive_on_handler_klass_exceptions
+    attr_writer   :error_handling_chain
+
+    def keep_alive_on_handler_klass_exceptions=(val)
+      @keep_alive_on_handler_klass_exceptions = val
+      @error_handling_chain = nil
+    end
+    def requeue_on_error=(val)
+      @requeue_on_error = val
+      @error_handling_chain = nil
+    end
 
     def initialize
       @rabbit_mq_host        = nil
@@ -59,6 +68,21 @@ module Pwwka
 
     def allow_delayed?
       options[:allow_delayed]
+    end
+
+    def error_handling_chain
+      @error_handling_chain ||= begin
+                                  klasses = []
+                                  if requeue_on_error
+                                    klasses << Pwwka::ErrorHandlers::NackAndRequeueOnce
+                                  else
+                                    klasses << Pwwka::ErrorHandlers::NackAndIgnore
+                                  end
+                                  unless Pwwka.configuration.keep_alive_on_handler_klass_exceptions?
+                                    klasses << Pwwka::ErrorHandlers::Crash
+                                  end
+                                  klasses
+                                end
     end
 
   end

--- a/lib/pwwka/configuration.rb
+++ b/lib/pwwka/configuration.rb
@@ -64,12 +64,12 @@ module Pwwka
     def error_handling_chain
       @error_handling_chain ||= begin
                                   klasses = []
-                                  if requeue_on_error
+                                  if self.requeue_on_error
                                     klasses << Pwwka::ErrorHandlers::NackAndRequeueOnce
                                   else
                                     klasses << Pwwka::ErrorHandlers::NackAndIgnore
                                   end
-                                  unless Pwwka.configuration.keep_alive_on_handler_klass_exceptions?
+                                  unless self.keep_alive_on_handler_klass_exceptions?
                                     klasses << Pwwka::ErrorHandlers::Crash
                                   end
                                   klasses

--- a/lib/pwwka/error_handlers.rb
+++ b/lib/pwwka/error_handlers.rb
@@ -1,0 +1,5 @@
+require_relative "error_handlers/chain"
+require_relative "error_handlers/base_error_handler"
+require_relative "error_handlers/crash"
+require_relative "error_handlers/nack_and_requeue_once"
+require_relative "error_handlers/nack_and_ignore"

--- a/lib/pwwka/error_handlers/base_error_handler.rb
+++ b/lib/pwwka/error_handlers/base_error_handler.rb
@@ -1,0 +1,33 @@
+module Pwwka
+  module ErrorHandlers
+    class BaseErrorHandler
+      include Pwwka::Logging
+      def handle_error(receiver,queue_name,payload,delivery_info,exception)
+        raise "subclass must implement"
+      end
+
+    private
+
+      def log(message,queue_name,payload,delivery_info,exception)
+        logf "%{message} on %{queue_name} -> %{payload}, %{routing_key}: %{exception}: %{backtrace}", {
+          message: message,
+          queue_name: queue_name,
+          payload: payload,
+          routing_key: delivery_info.routing_key,
+          exception: exception,
+          backtrace: exception.backtrace.join(";"),
+        }
+      end
+
+      # Subclasses can call these methods instead of
+      # using true/false to more clearly indicate their intent
+      def keep_going
+        true
+      end
+
+      def abort_chain
+        false
+      end
+    end
+  end
+end

--- a/lib/pwwka/error_handlers/chain.rb
+++ b/lib/pwwka/error_handlers/chain.rb
@@ -1,0 +1,28 @@
+module Pwwka
+  module ErrorHandlers
+    # Given a chain of error handlers, calls them until either
+    # one returns false/aborts or we exhaust the chain of handlers
+    class Chain
+      include Pwwka::Logging
+      def initialize(default_handler_chain=[])
+        @error_handlers = default_handler_chain
+      end
+      def handle_error(message_handler_klass,receiver,queue_name,payload,delivery_info,exception)
+        if message_handler_klass.respond_to?(:error_handler)
+          @error_handlers.unshift(message_handler_klass.send(:error_handler))
+        end
+        @error_handlers.reduce(true) { |keep_going,error_handler|
+          if keep_going
+            keep_going = error_handler.new.handle_error(receiver,queue_name,payload,delivery_info,exception)
+            unless keep_going
+              logf "%{error_handler_class} has halted to error-handling chain", error_handler_class: error_handler.class
+            end
+          else
+            logf "Skipping %{error_handler_class} as we were asked to abort previously", error_handler_class: error_handler.class
+          end
+          keep_going
+        }
+      end
+    end
+  end
+end

--- a/lib/pwwka/error_handlers/crash.rb
+++ b/lib/pwwka/error_handlers/crash.rb
@@ -1,0 +1,11 @@
+require_relative "base_error_handler"
+module Pwwka
+  module ErrorHandlers
+    class Crash < BaseErrorHandler
+      def handle_error(receiver,queue_name,payload,delivery_info,e)
+        raise Interrupt,"Exiting due to exception #{e.inspect}"
+        abort_chain
+      end
+    end
+  end
+end

--- a/lib/pwwka/error_handlers/nack_and_ignore.rb
+++ b/lib/pwwka/error_handlers/nack_and_ignore.rb
@@ -1,0 +1,13 @@
+require_relative "base_error_handler"
+module Pwwka
+  module ErrorHandlers
+    class NackAndIgnore < BaseErrorHandler
+      def handle_error(receiver,queue_name,payload,delivery_info,exception)
+        log("Error Processing Message",queue_name,payload,delivery_info,exception)
+        receiver.nack(delivery_info.delivery_tag)
+        keep_going
+      end
+    end
+
+  end
+end

--- a/lib/pwwka/error_handlers/nack_and_requeue_once.rb
+++ b/lib/pwwka/error_handlers/nack_and_requeue_once.rb
@@ -1,0 +1,17 @@
+require_relative "base_error_handler"
+module Pwwka
+  module ErrorHandlers
+    class NackAndRequeueOnce < BaseErrorHandler
+      def handle_error(receiver,queue_name,payload,delivery_info,exception)
+        if delivery_info.redelivered
+          log("Error Processing Message",queue_name,payload,delivery_info,exception)
+          receiver.nack(delivery_info.delivery_tag)
+        else
+          log("Retrying an Error Processing Message",queue_name,payload,delivery_info,exception)
+          receiver.nack_requeue(delivery_info.delivery_tag)
+        end
+        keep_going
+      end
+    end
+  end
+end

--- a/lib/pwwka/receiver.rb
+++ b/lib/pwwka/receiver.rb
@@ -42,7 +42,11 @@ module Pwwka
               log_error "Error Processing Message", error_options
               receiver.nack(delivery_info.delivery_tag)
             end
-            unless Pwwka.configuration.keep_alive_on_handler_klass_exceptions?
+            if handler_klass.respond_to?(:on_unhandled_error)
+              handler_klass.on_unhandled_error(e)
+            elsif Pwwka.configuration.keep_alive_on_handler_klass_exceptions?
+              # no op
+            else
               raise Interrupt,"Exiting due to exception #{e.inspect}"
             end
           end

--- a/lib/pwwka/version.rb
+++ b/lib/pwwka/version.rb
@@ -1,3 +1,3 @@
 module Pwwka
-  VERSION = '0.13.0.RC1'
+  VERSION = '0.13.0.RC2'
 end

--- a/lib/pwwka/version.rb
+++ b/lib/pwwka/version.rb
@@ -1,3 +1,3 @@
 module Pwwka
-  VERSION = '0.12.0'
+  VERSION = '0.13.0.RC1'
 end

--- a/spec/integration/unhandled_errors_in_receivers_spec.rb
+++ b/spec/integration/unhandled_errors_in_receivers_spec.rb
@@ -8,6 +8,7 @@ describe "receivers with unhandled errors", :integration do
 
   before do
     @testing_setup = IntegrationTestSetup.new
+    Pwwka.configuration.instance_variable_set("@error_handling_chain",nil)
     Pwwka.configure do |c|
       c.requeue_on_error = false
       c.keep_alive_on_handler_klass_exceptions = false

--- a/spec/integration/unhandled_errors_in_receivers_spec.rb
+++ b/spec/integration/unhandled_errors_in_receivers_spec.rb
@@ -8,88 +8,122 @@ describe "receivers with unhandled errors", :integration do
 
   before do
     @testing_setup = IntegrationTestSetup.new
-    setup_receivers
     Pwwka.configure do |c|
       c.requeue_on_error = false
       c.keep_alive_on_handler_klass_exceptions = false
     end
   end
 
-  before :each do
-    WellBehavedReceiver.reset!
-    ExceptionThrowingReceiver.reset!
-    IntermittentErrorReceiver.reset!
-  end
-
   after do
     @testing_setup.kill_threads_and_clear_queues
   end
 
-  it "an error in one receiver doesn't prevent others from getting messages" do
-    Pwwka::Transmitter.send_message!({ sample: "payload", has: { deeply: true, nested: 4 }},
-                                     "pwwka.testing.foo")
-    allow_receivers_to_process_queues
-
-    expect(WellBehavedReceiver.messages_received.size).to eq(1)
-    expect(ExceptionThrowingReceiver.messages_received.size).to eq(1)
-  end
-
-  it "when configured to requeue failed messages, the message is requeued exactly once" do
-    Pwwka.configure do |c|
-      c.requeue_on_error = true
-      c.keep_alive_on_handler_klass_exceptions = true # only so we can check that the requeued message got sent; otherwise the receiver crashes and we can't test that
+  context "default configuration to crash on errors" do
+    before do
+      setup_receivers
+      WellBehavedReceiver.reset!
+      ExceptionThrowingReceiver.reset!
+      IntermittentErrorReceiver.reset!
     end
-    Pwwka::Transmitter.send_message!({ sample: "payload", has: { deeply: true, nested: 4 }},
-                                     "pwwka.testing.foo")
-    allow_receivers_to_process_queues
 
-    expect(WellBehavedReceiver.messages_received.size).to eq(1)
-    expect(ExceptionThrowingReceiver.messages_received.size).to eq(2)
-    expect(ExceptionThrowingReceiver.messages_received[1][0].redelivered).to eq(true)
-    expect(ExceptionThrowingReceiver.messages_received[1][2]).to eq(ExceptionThrowingReceiver.messages_received[0][2])
-  end
+    it "an error in one receiver doesn't prevent others from getting messages" do
+      Pwwka::Transmitter.send_message!({ sample: "payload", has: { deeply: true, nested: 4 }},
+                                       "pwwka.testing.foo")
+      allow_receivers_to_process_queues
 
-  it "crashes the receiver that received an error" do
-    Pwwka::Transmitter.send_message!({ sample: "payload", has: { deeply: true, nested: 4 }},
-                                     "pwwka.testing.foo")
-    allow_receivers_to_process_queues
-
-    expect(@testing_setup.threads[ExceptionThrowingReceiver].alive?).to eq(false)
-  end
-
-  it "does not crash the receiver that received an error when we configure it not to" do
-    Pwwka.configure do |c|
-      c.keep_alive_on_handler_klass_exceptions = true
+      expect(WellBehavedReceiver.messages_received.size).to eq(1)
+      expect(ExceptionThrowingReceiver.messages_received.size).to eq(1)
     end
-    Pwwka::Transmitter.send_message!({ sample: "payload", has: { deeply: true, nested: 4 }},
-                                     "pwwka.testing.foo")
-    allow_receivers_to_process_queues
+    it "crashes the receiver that received an error" do
+      Pwwka::Transmitter.send_message!({ sample: "payload", has: { deeply: true, nested: 4 }},
+                                       "pwwka.testing.foo")
+      allow_receivers_to_process_queues
 
-    expect(@testing_setup.threads[ExceptionThrowingReceiver].alive?).to eq(true)
-  end
-
-  it "does not crash the receiver that successfully processed a message" do
-    Pwwka::Transmitter.send_message!({ sample: "payload", has: { deeply: true, nested: 4 }},
-                                     "pwwka.testing.foo")
-    allow_receivers_to_process_queues
-
-    expect(@testing_setup.threads[WellBehavedReceiver].alive?).to  eq(true)
-  end
-
-  it "crashes the receiver if it gets a failure that we retry" do
-    Pwwka.configure do |c|
-      c.requeue_on_error = true
+      expect(@testing_setup.threads[ExceptionThrowingReceiver].alive?).to eq(false)
     end
-    Pwwka::Transmitter.send_message!({ sample: "payload", has: { deeply: true, nested: 4 }},
-                                     "pwwka.testing.foo")
-    allow_receivers_to_process_queues
+    it "does not crash the receiver that successfully processed a message" do
+      Pwwka::Transmitter.send_message!({ sample: "payload", has: { deeply: true, nested: 4 }},
+                                       "pwwka.testing.foo")
+      allow_receivers_to_process_queues
 
-    expect(@testing_setup.threads[IntermittentErrorReceiver].alive?).to eq(false)
+      expect(@testing_setup.threads[WellBehavedReceiver].alive?).to  eq(true)
+    end
+
+    it "crashes the receiver if it gets a failure that we retry" do
+      Pwwka.configure do |c|
+        c.requeue_on_error = true
+      end
+      Pwwka::Transmitter.send_message!({ sample: "payload", has: { deeply: true, nested: 4 }},
+                                       "pwwka.testing.foo")
+      allow_receivers_to_process_queues
+
+      expect(@testing_setup.threads[IntermittentErrorReceiver].alive?).to eq(false)
+    end
   end
 
-  def setup_receivers
+  context "configured not to crash on error" do
+    before do
+      setup_receivers
+      WellBehavedReceiver.reset!
+      ExceptionThrowingReceiver.reset!
+      IntermittentErrorReceiver.reset!
+    end
+    it "does not crash the receiver that received an error" do
+      Pwwka.configure do |c|
+        c.keep_alive_on_handler_klass_exceptions = true
+      end
+      Pwwka::Transmitter.send_message!({ sample: "payload", has: { deeply: true, nested: 4 }},
+                                       "pwwka.testing.foo")
+      allow_receivers_to_process_queues
+
+      expect(@testing_setup.threads[ExceptionThrowingReceiver].alive?).to eq(true)
+    end
+  end
+
+  context "configured to requeue failed messages" do
+    before do
+      setup_receivers
+      WellBehavedReceiver.reset!
+      ExceptionThrowingReceiver.reset!
+      IntermittentErrorReceiver.reset!
+    end
+    it "requeues the message exactly once" do
+      Pwwka.configure do |c|
+        c.requeue_on_error = true
+        c.keep_alive_on_handler_klass_exceptions = true # only so we can check that the requeued message got sent; otherwise the receiver crashes and we can't test that
+      end
+      Pwwka::Transmitter.send_message!({ sample: "payload", has: { deeply: true, nested: 4 }},
+                                       "pwwka.testing.foo")
+      allow_receivers_to_process_queues
+
+      expect(WellBehavedReceiver.messages_received.size).to eq(1)
+      expect(ExceptionThrowingReceiver.messages_received.size).to eq(2)
+      expect(ExceptionThrowingReceiver.messages_received[1][0].redelivered).to eq(true)
+      expect(ExceptionThrowingReceiver.messages_received[1][2]).to eq(ExceptionThrowingReceiver.messages_received[0][2])
+    end
+  end
+
+  context "handler with a custom error hook that ignores the exception" do
+    before do
+      setup_receivers(ExceptionThrowingReceiverWithErrorHook)
+      WellBehavedReceiver.reset!
+      ExceptionThrowingReceiverWithErrorHook.reset!
+      IntermittentErrorReceiver.reset!
+    end
+
+    it "does not crash the receiver" do
+      Pwwka::Transmitter.send_message!({ sample: "payload", has: { deeply: true, nested: 4 }},
+                                       "pwwka.testing.foo")
+      allow_receivers_to_process_queues
+
+      expect(ExceptionThrowingReceiverWithErrorHook.messages_received.size).to eq(1)
+      expect(@testing_setup.threads[ExceptionThrowingReceiverWithErrorHook].alive?).to eq(true)
+    end
+  end
+
+  def setup_receivers(exception_throwing_receiver_klass=ExceptionThrowingReceiver)
     [
-      [ExceptionThrowingReceiver, "exception_throwing_receiver_pwwkatesting"],
+      [exception_throwing_receiver_klass, "exception_throwing_receiver_pwwkatesting"],
       [WellBehavedReceiver, "well_behaved_receiver_pwwkatesting"],
       [IntermittentErrorReceiver, "intermittent_error_receiver_pwwkatesting"],
     ].each do |(klass, queue_name)|
@@ -97,6 +131,16 @@ describe "receivers with unhandled errors", :integration do
     end
   end
   class ExceptionThrowingReceiver < LoggingReceiver
+    def self.handle!(delivery_info,properties,payload)
+      super(delivery_info,properties,payload)
+      raise "OH NOES!"
+    end
+  end
+  class ExceptionThrowingReceiverWithErrorHook < LoggingReceiver
+    def self.on_unhandled_error(exception)
+      # not crashing
+    end
+
     def self.handle!(delivery_info,properties,payload)
       super(delivery_info,properties,payload)
       raise "OH NOES!"

--- a/spec/unit/configuration_spec.rb
+++ b/spec/unit/configuration_spec.rb
@@ -79,4 +79,44 @@ describe Pwwka::Configuration do
       end
     end
   end
+
+  describe "#error_handling_chain" do
+    before do
+      configuration.instance_variable_set("@error_handling_chain",nil)
+    end
+    context "implicit configuration" do
+      context "when requeue_on_error" do
+        context "when keep_alive_on_handler_klass_exceptions" do
+          it "is NackAndRequeueOnce" do
+            configuration.requeue_on_error = true
+            configuration.keep_alive_on_handler_klass_exceptions = true
+            expect(configuration.error_handling_chain).to eq([Pwwka::ErrorHandlers::NackAndRequeueOnce])
+          end
+        end
+        context "when not keep_alive_on_handler_klass_exceptions" do
+          it "is NackAndRequeueOnce,Crash" do
+            configuration.requeue_on_error = true
+            configuration.keep_alive_on_handler_klass_exceptions = false
+            expect(configuration.error_handling_chain).to eq([Pwwka::ErrorHandlers::NackAndRequeueOnce,Pwwka::ErrorHandlers::Crash])
+          end
+        end
+      end
+      context "when not requeue_on_error" do
+        context "when keep_alive_on_handler_klass_exceptions" do
+          it "is NackAndIgnore" do
+            configuration.requeue_on_error = false
+            configuration.keep_alive_on_handler_klass_exceptions = true
+            expect(configuration.error_handling_chain).to eq([Pwwka::ErrorHandlers::NackAndIgnore])
+          end
+        end
+        context "when not keep_alive_on_handler_klass_exceptions" do
+          it "is NackAndIgnore,Crash" do
+            configuration.requeue_on_error = false
+            configuration.keep_alive_on_handler_klass_exceptions = false
+            expect(configuration.error_handling_chain).to eq([Pwwka::ErrorHandlers::NackAndIgnore,Pwwka::ErrorHandlers::Crash])
+          end
+        end
+      end
+    end
+  end
 end


### PR DESCRIPTION
# Problem

Elrang's "let it crash" is fine for intermittent failures, but for things that can happen regularly, it's not necessarily the best pattern, especially since a restart means restarting rails.

# Solution

Provide the framework for handling errors more intentionally.

~Any handler class can implement `on_unhandled_error` and do whatever it wants, including not crashing.~

~~This is a light touch we could build upon, but wanted to get some feedback before doing too much work.~~

*Update* this breaks out *all* of pwwka's error handling into a Chain of Responsibility such that we can more easily manipulate it.

The README outlines the use case we want this for internally, but this could also be leveraged to solve #51 

It also means that Stitch Fix can come up with the One True Pwwka Configuration™ for us, that's based on some internal things not appropriate for this gem and without making this gem have more config options.