### PR TITLE
Define Pwwka::ErrorHandlers module to make it requirable

### DIFF
--- a/lib/pwwka/error_handlers.rb
+++ b/lib/pwwka/error_handlers.rb
@@ -1,3 +1,8 @@
+module Pwwka
+  module ErrorHandlers
+  end
+end
+
 require_relative "error_handlers/chain"
 require_relative "error_handlers/base_error_handler"
 require_relative "error_handlers/crash"


### PR DESCRIPTION
# Problem

`require 'pwwka/error_handlers'` fails with `NameError: uninitialized constant Pwwka::ErrorHandlers`

requiring 'pwwka/error_handlers' from client code is required for functionality described in https://github.com/stitchfix/pwwka#advanced-error-handling

# Solution 

Define the constant so it can be required