### PR TITLE
Chain#handler_error: fix logf format

### DIFF
--- a/lib/pwwka/error_handlers/chain.rb
+++ b/lib/pwwka/error_handlers/chain.rb
@@ -8,7 +8,7 @@ module Pwwka
         @error_handlers = default_handler_chain
       end
       def handle_error(message_handler_klass,receiver,queue_name,payload,delivery_info,exception)
-        logf "${message_handler_klass} has received ${exception}", message_handler_klass: message_handler_klass, exception: exception.message
+        logf "%{message_handler_klass} has received %{exception}", message_handler_klass: message_handler_klass, exception: exception.message
         if message_handler_klass.respond_to?(:error_handler)
           @error_handlers.unshift(message_handler_klass.send(:error_handler))
         end


### PR DESCRIPTION
Changes `logf` flag in error message string from `$` -> `%`