### PR TITLE
Fix error payload logging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ db
 .rspec
 .bundle
 coverage
+Session.vim

--- a/lib/pwwka/error_handlers/chain.rb
+++ b/lib/pwwka/error_handlers/chain.rb
@@ -8,7 +8,7 @@ module Pwwka
         @error_handlers = default_handler_chain
       end
       def handle_error(message_handler_klass,receiver,queue_name,payload,delivery_info,exception)
-        logf "%{message_handler_klass} has received %{exception}", at: :error, message_handler_klass: message_handler_klass, exception: exception.message
+        logf "Error Processing Message in %{message_handler_klass} due to %{exception} from payload '%{payload}'", at: :error, message_handler_klass: message_handler_klass, exception: exception.message, payload: payload
         if message_handler_klass.respond_to?(:error_handler)
           @error_handlers.unshift(message_handler_klass.send(:error_handler))
         end

--- a/spec/unit/logging_spec.rb
+++ b/spec/unit/logging_spec.rb
@@ -7,6 +7,9 @@ describe Pwwka::Logging do
   end
 
   it "returns the logger" do
+    Pwwka.configure do |c|
+      c.logger = MonoLogger.new(STDOUT)
+    end
     expect(ForLogging.logger).to be_instance_of(MonoLogger)
   end
 


### PR DESCRIPTION
# Problem

When the code was refactored to use chained error handlers, the error log-level was lost, meaning we lost payload-logging for unhandled messages

# Solution

Log the payload, at error, whenever a message can't be processed.

This slightly changes the semantics, in that a message that is retried *will* have this error message, but it will also log the retry, so I think the log will have enough info to 100% understand what happened in the case of errors.