### PR TITLE
Allow a prefetch value to be set for subscribers

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ Pwwka.configure do |config|
   config.delayed_exchange_name = "mycompany-topics-#{Rails.env}"
   config.options               = {allow_delayed: true}
   config.requeue_on_error      = true
+  config.prefetch              = 10
 end
 ```
 
@@ -211,6 +212,7 @@ It requires some environment variables to work:
 * `HANDLER_KLASS` (required) refers to the class you have to write in your app (equivalent to a `job` in Resque)
 * `QUEUE_NAME` (required) we must use named queues - see below
 * `ROUTING_KEY` (optional) defaults to `#.#` (all messages)
+* `PREFETCH` (optional) sets a [prefetch value](http://rubybunny.info/articles/queues.html#qos__prefetching_messages) for the subscriber
 
 You'll also need to bring the Rake task into your app.  For Rails, you'll need to edit the top-level `Rakefile`:
 

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Pwwka.configure do |config|
   config.delayed_exchange_name = "mycompany-topics-#{Rails.env}"
   config.options               = {allow_delayed: true}
   config.requeue_on_error      = true
-  config.prefetch              = 10
+  config.default_prefetch      = 10
 end
 ```
 

--- a/lib/pwwka/channel_connector.rb
+++ b/lib/pwwka/channel_connector.rb
@@ -15,6 +15,9 @@ module Pwwka
                                   connection_options)
       @connection.start
       @channel           = @connection.create_channel
+      if @configuration.prefetch
+        @channel.prefetch(@configuration.prefetch)
+      end
     end
 
     def topic_exchange

--- a/lib/pwwka/channel_connector.rb
+++ b/lib/pwwka/channel_connector.rb
@@ -8,15 +8,15 @@ module Pwwka
     # The channel_connector starts the connection to the message_bus
     # so it should only be instantiated by a method that has a strategy
     # for closing the connection
-    def initialize
+    def initialize(prefetch: nil)
       @configuration     = Pwwka.configuration
       connection_options = {automatically_recover: false}.merge(configuration.options)
       @connection        = Bunny.new(configuration.rabbit_mq_host,
                                   connection_options)
       @connection.start
       @channel           = @connection.create_channel
-      if @configuration.prefetch
-        @channel.prefetch(@configuration.prefetch)
+      if prefetch
+        @channel.prefetch(prefetch.to_i)
       end
     end
 

--- a/lib/pwwka/configuration.rb
+++ b/lib/pwwka/configuration.rb
@@ -11,6 +11,7 @@ module Pwwka
     attr_accessor :options
     attr_accessor :async_job_klass
     attr_accessor :send_message_resque_backoff_strategy
+    attr_accessor :prefetch
     attr_reader   :requeue_on_error
     attr_writer   :app_id
     attr_writer   :error_handling_chain
@@ -27,6 +28,7 @@ module Pwwka
       @requeue_on_error = false
       @keep_alive_on_handler_klass_exceptions = false
       @async_job_klass = Pwwka::SendMessageAsyncJob
+      @prefetch = nil
     end
 
     def keep_alive_on_handler_klass_exceptions?
@@ -98,6 +100,10 @@ module Pwwka
           @error_handling_chain[index] = Pwwka::ErrorHandlers::NackAndIgnore
         end
       end
+    end
+
+    def prefetch=(val)
+      @prefetch = val.nil? ? val : val.to_i
     end
   end
 end

--- a/lib/pwwka/configuration.rb
+++ b/lib/pwwka/configuration.rb
@@ -11,7 +11,7 @@ module Pwwka
     attr_accessor :options
     attr_accessor :async_job_klass
     attr_accessor :send_message_resque_backoff_strategy
-    attr_accessor :prefetch
+    attr_accessor :default_prefetch
     attr_reader   :requeue_on_error
     attr_writer   :app_id
     attr_writer   :error_handling_chain
@@ -28,7 +28,7 @@ module Pwwka
       @requeue_on_error = false
       @keep_alive_on_handler_klass_exceptions = false
       @async_job_klass = Pwwka::SendMessageAsyncJob
-      @prefetch = nil
+      @default_prefetch = nil
     end
 
     def keep_alive_on_handler_klass_exceptions?
@@ -102,8 +102,8 @@ module Pwwka
       end
     end
 
-    def prefetch=(val)
-      @prefetch = val.nil? ? val : val.to_i
+    def default_prefetch=(val)
+      @default_prefetch = val.nil? ? val : val.to_i
     end
   end
 end

--- a/lib/pwwka/receiver.rb
+++ b/lib/pwwka/receiver.rb
@@ -9,17 +9,17 @@ module Pwwka
     attr_reader :queue_name
     attr_reader :routing_key
 
-    def initialize(queue_name, routing_key)
+    def initialize(queue_name, routing_key, prefetch: Pwwka.configuration.default_prefetch)
       @queue_name        = queue_name
       @routing_key       = routing_key
-      @channel_connector = ChannelConnector.new
+      @channel_connector = ChannelConnector.new(prefetch: prefetch)
       @channel           = @channel_connector.channel
       @topic_exchange    = @channel_connector.topic_exchange
     end
 
-    def self.subscribe(handler_klass, queue_name, routing_key: "#.#", block: true)
+    def self.subscribe(handler_klass, queue_name, routing_key: "#.#", block: true, prefetch: Pwwka.configuration.default_prefetch)
       raise "#{handler_klass.name} must respond to `handle!`" unless handler_klass.respond_to?(:handle!)
-      receiver  = new(queue_name, routing_key)
+      receiver  = new(queue_name, routing_key, prefetch: prefetch)
       begin
         info "Receiving on #{queue_name}"
         receiver.topic_queue.subscribe(manual_ack: true, block: block) do |delivery_info, properties, payload|

--- a/lib/pwwka/tasks.rb
+++ b/lib/pwwka/tasks.rb
@@ -6,8 +6,8 @@ namespace :message_handler do
     handler_klass = ENV['HANDLER_KLASS'].constantize
     queue_name    = "#{ENV['QUEUE_NAME']}_#{Rails.env}"
     routing_key   = ENV['ROUTING_KEY'] || "#.#"
-    Pwwka.configuration.prefetch = ENV['PREFETCH'] if ENV.has_key?('PREFETCH')
+    prefetch = ENV['PREFETCH'] || Pwwka.configuration.default_prefetch
 
-    Pwwka::Receiver.subscribe(handler_klass, queue_name, routing_key: routing_key)
+    Pwwka::Receiver.subscribe(handler_klass, queue_name, routing_key: routing_key, prefetch: prefetch)
   end
 end

--- a/lib/pwwka/tasks.rb
+++ b/lib/pwwka/tasks.rb
@@ -6,6 +6,8 @@ namespace :message_handler do
     handler_klass = ENV['HANDLER_KLASS'].constantize
     queue_name    = "#{ENV['QUEUE_NAME']}_#{Rails.env}"
     routing_key   = ENV['ROUTING_KEY'] || "#.#"
+    Pwwka.configuration.prefetch = ENV['PREFETCH'] if ENV.has_key?('PREFETCH')
+
     Pwwka::Receiver.subscribe(handler_klass, queue_name, routing_key: routing_key)
   end
 end

--- a/spec/unit/channel_connector_spec.rb
+++ b/spec/unit/channel_connector_spec.rb
@@ -16,10 +16,15 @@ describe Pwwka::ChannelConnector do
     end
 
     it "sets a prefetch value if configured to do so" do
-      allow(Pwwka.configuration).to receive(:prefetch).and_return(10)
       expect(bunny_channel).to receive(:prefetch).with(10)
 
-      channel_connector
+      described_class.new(prefetch: 10)
+    end
+
+    it "does not set a prefetch value unless configured" do
+      expect(bunny_channel).not_to receive(:prefetch).with(10)
+
+      described_class.new
     end
   end
 

--- a/spec/unit/channel_connector_spec.rb
+++ b/spec/unit/channel_connector_spec.rb
@@ -4,21 +4,37 @@ require 'spec_helper.rb'
 # by the integration tests.
 describe Pwwka::ChannelConnector do
   let(:bunny_session) { instance_double(Bunny::Session) }
-
-  before do
-    allow(Bunny).to receive(:new).and_return(bunny_session)
-    allow(bunny_session).to receive(:start)
-    allow(bunny_session).to receive(:create_channel)
-    @default_allow_delayed = Pwwka.configuration.options[:allow_delayed]
-  end
-
-  after do
-    Pwwka.configuration.options[:allow_delayed] = @default_allow_delayed
-  end
-
   subject(:channel_connector) { described_class.new }
 
+  describe "initialize" do
+    let(:bunny_channel) { instance_double(Bunny::Channel) }
+
+    before do
+      allow(Bunny).to receive(:new).and_return(bunny_session)
+      allow(bunny_session).to receive(:start)
+      allow(bunny_session).to receive(:create_channel).and_return(bunny_channel)
+    end
+
+    it "sets a prefetch value if configured to do so" do
+      allow(Pwwka.configuration).to receive(:prefetch).and_return(10)
+      expect(bunny_channel).to receive(:prefetch).with(10)
+
+      channel_connector
+    end
+  end
+
   describe "raise_if_delayed_not_allowed" do
+    before do
+      allow(Bunny).to receive(:new).and_return(bunny_session)
+      allow(bunny_session).to receive(:start)
+      allow(bunny_session).to receive(:create_channel)
+      @default_allow_delayed = Pwwka.configuration.options[:allow_delayed]
+    end
+
+    after do
+      Pwwka.configuration.options[:allow_delayed] = @default_allow_delayed
+    end
+
     context "delayed is configured" do
       it "does not blow up" do
         Pwwka.configuration.options[:allow_delayed] = true

--- a/spec/unit/configuration_spec.rb
+++ b/spec/unit/configuration_spec.rb
@@ -119,4 +119,18 @@ describe Pwwka::Configuration do
       end
     end
   end
+
+  describe "#prefetch" do
+    it "is nil by default" do
+      expect(configuration.prefetch).to be_nil
+    end
+
+    it "is a number" do
+      configuration.prefetch = 10
+      expect(configuration.prefetch).to eq(10)
+      configuration.prefetch = "10"
+      expect(configuration.prefetch).to eq(10)
+    end
+  end
+
 end

--- a/spec/unit/configuration_spec.rb
+++ b/spec/unit/configuration_spec.rb
@@ -120,16 +120,16 @@ describe Pwwka::Configuration do
     end
   end
 
-  describe "#prefetch" do
+  describe "#default_prefetch" do
     it "is nil by default" do
-      expect(configuration.prefetch).to be_nil
+      expect(configuration.default_prefetch).to be_nil
     end
 
     it "is a number" do
-      configuration.prefetch = 10
-      expect(configuration.prefetch).to eq(10)
-      configuration.prefetch = "10"
-      expect(configuration.prefetch).to eq(10)
+      configuration.default_prefetch = 10
+      expect(configuration.default_prefetch).to eq(10)
+      configuration.default_prefetch = "10"
+      expect(configuration.default_prefetch).to eq(10)
     end
   end
 


### PR DESCRIPTION
This sets the basic.qos prefetch value for Rabbit. This can be set globally with Pwwka.configuration.prefetch= or with the PREFETCH environment variable.