### PR TITLE
Make Pwwka:ErrorHandlers::Chain log exceptions

### DIFF
--- a/lib/pwwka/error_handlers/chain.rb
+++ b/lib/pwwka/error_handlers/chain.rb
@@ -27,7 +27,7 @@ module Pwwka
             end
             keep_going
           rescue StandardError => exception
-            logf "'%{error_handler_class}' failed with exception '%{exception}'", at: :fatal, error_handler_class: error_handler, exception: exception
+            logf "'%{error_handler_class}' aborting due to unhandled exception '%{exception}'", at: :fatal, error_handler_class: error_handler, exception: exception
             abort
           end
         }

--- a/lib/pwwka/error_handlers/chain.rb
+++ b/lib/pwwka/error_handlers/chain.rb
@@ -28,7 +28,7 @@ module Pwwka
             keep_going
           rescue StandardError => exception
             logf "'%{error_handler_class}' aborting due to unhandled exception '%{exception}'", at: :fatal, error_handler_class: error_handler, exception: exception
-            abort
+            false
           end
         }
       end

--- a/spec/integration/unhandled_errors_in_receivers_spec.rb
+++ b/spec/integration/unhandled_errors_in_receivers_spec.rb
@@ -5,6 +5,19 @@ require_relative "support/integration_test_setup"
 require_relative "support/logging_receiver"
 require_relative "support/integration_test_helpers"
 
+class PoorlyBehavingErrorHandler < Pwwka::ErrorHandlers::BaseErrorHandler
+  def handle_error(receiver,queue_name,payload,delivery_info,exception)
+    raise "whoops, do I break everything behind me?"
+    keep_going
+  end
+end
+
+class ErrorHandlerThatWorksFine < Pwwka::ErrorHandlers::BaseErrorHandler
+  def handle_error(receiver,queue_name,payload,delivery_info,exception)
+    keep_going
+  end
+end
+
 class EvilPayload
   def to_json
     "This is not JSON by any stretch"
@@ -164,6 +177,31 @@ describe "receivers with unhandled errors", :integration do
 
       expect(ExceptionThrowingReceiverWithErrorHook.messages_received.size).to eq(1)
       expect(@testing_setup.threads[ExceptionThrowingReceiverWithErrorHook].alive?).to eq(true)
+    end
+  end
+
+  context "handler with a custom error handler throws in the pwwka error handling chain throws its own exception" do
+    before do
+      setup_receivers(ExceptionThrowingReceiver)
+      WellBehavedReceiver.reset!
+      ExceptionThrowingReceiver.reset!
+      IntermittentErrorReceiver.reset!
+      ExceptionThrowingReceiverWithErrorHook.reset!
+    end
+
+    it "confirms subsequent error handlers do not run when there is an exception earlier in the chain" do
+			Pwwka.configuration.instance_variable_set("@error_handling_chain",
+				[
+          PoorlyBehavingErrorHandler,
+          ErrorHandlerThatWorksFine
+			  ])
+
+      Pwwka::Transmitter.send_message!({ sample: "payload", has: { deeply: true, nested: 4 }},
+                                       "pwwka.testing.foo")
+      allow_receivers_to_process_queues
+
+      expect(ExceptionThrowingReceiver.messages_received.size).to eq(1)
+      expect(@testing_setup.threads[ExceptionThrowingReceiver].alive?).to eq(true)
     end
   end
 

--- a/spec/lib/pwwka/error_handlers/chain_spec.rb
+++ b/spec/lib/pwwka/error_handlers/chain_spec.rb
@@ -1,0 +1,10 @@
+require "spec_helper"
+
+describe Pwwka::ErrorHandlers::Chain do
+  let(:subject) { described_class.new(default_handler_chain) }
+
+  describe "#handle_error" do
+    xit "logs exceptions that occur in the error handling chain" do
+    end
+  end
+end

--- a/spec/lib/pwwka/error_handlers/chain_spec.rb
+++ b/spec/lib/pwwka/error_handlers/chain_spec.rb
@@ -32,7 +32,7 @@ describe Pwwka::ErrorHandlers::Chain do
 
       it "logs exceptions that occur in the error handling chain" do
         expect(chain.logger).to receive(:send).with(any_args).exactly(2).times
-        expect(chain.logger).to receive(:send).with(:fatal, /failed with exception/)
+        expect(chain.logger).to receive(:send).with(:fatal, /aborting due to unhandled exception/)
 
         expect {
           chain.handle_error(double,double,double,double,double,double.as_null_object)

--- a/spec/lib/pwwka/error_handlers/chain_spec.rb
+++ b/spec/lib/pwwka/error_handlers/chain_spec.rb
@@ -19,24 +19,14 @@ describe Pwwka::ErrorHandlers::Chain do
       it "does not run subsequent error handlers" do
         expect(good_error_handler_klass).to_not receive(:new)
 
-        expect {
-          chain.handle_error(double,double,double,double,double,double.as_null_object)
-        }.to raise_error(SystemExit)
-      end
-
-      it "aborts the process" do
-        expect {
-          chain.handle_error(double,double,double,double,double,double.as_null_object)
-        }.to raise_error(SystemExit)
+        chain.handle_error(double,double,double,double,double,double.as_null_object)
       end
 
       it "logs exceptions that occur in the error handling chain" do
-        expect(chain.logger).to receive(:send).with(any_args).exactly(2).times
+        allow(chain.logger).to receive(:send).with(any_args)
         expect(chain.logger).to receive(:send).with(:fatal, /aborting due to unhandled exception/)
 
-        expect {
-          chain.handle_error(double,double,double,double,double,double.as_null_object)
-        }.to raise_error(SystemExit)
+        chain.handle_error(double,double,double,double,double,double.as_null_object)
       end
     end
   end

--- a/spec/lib/pwwka/error_handlers/chain_spec.rb
+++ b/spec/lib/pwwka/error_handlers/chain_spec.rb
@@ -1,10 +1,43 @@
 require "spec_helper"
 
 describe Pwwka::ErrorHandlers::Chain do
-  let(:subject) { described_class.new(default_handler_chain) }
+  subject(:chain) { described_class.new(default_handler_chain) }
 
   describe "#handle_error" do
-    xit "logs exceptions that occur in the error handling chain" do
+    context "when an error handler raises an unhandled exception" do
+      let(:default_handler_chain) { [bad_error_handler_klass, good_error_handler_klass] }
+      let(:bad_error_handler_klass) { double("bad error handler klass", new: bad_error_handler) }
+      let(:bad_error_handler) {
+        handler = double("bad error handler")
+        allow(handler).to receive(:handle_error).and_raise("unhandled exception in error handler")
+        handler
+      }
+      let(:good_error_handler_klass) { double("good error handler klass") }
+
+      before { allow(bad_error_handler).to receive(:error_handler).and_raise("Wibble") }
+
+      it "does not run subsequent error handlers" do
+        expect(good_error_handler_klass).to_not receive(:new)
+
+        expect {
+          chain.handle_error(double,double,double,double,double,double.as_null_object)
+        }.to raise_error(SystemExit)
+      end
+
+      it "aborts the process" do
+        expect {
+          chain.handle_error(double,double,double,double,double,double.as_null_object)
+        }.to raise_error(SystemExit)
+      end
+
+      it "logs exceptions that occur in the error handling chain" do
+        expect(chain.logger).to receive(:send).with(any_args).exactly(2).times
+        expect(chain.logger).to receive(:send).with(:fatal, /failed with exception/)
+
+        expect {
+          chain.handle_error(double,double,double,double,double,double.as_null_object)
+        }.to raise_error(SystemExit)
+      end
     end
   end
 end


### PR DESCRIPTION
We experienced an issue in COGS where an exception in the error_handling_chain
broke the chain unintentionally and left us with a worker that seemed to be
alive but was no longer processing errors.

There was no diagnostic information for us to determine what broke and how.

In this commit, I would like to make changes to the Chain class to log the
exceptions when they occur and identify which handler in the
error_handling_chain is responsible.

See https://docs.google.com/document/d/1BqwBP3two_w3m4KuFbR57yQwUoHng6T-XVmPNBmiWM0/edit#heading=h.udep7n7vrmim for the specific post-mortem.

I look forward to feedback as to whether this is a good approach or if there's a better approach to consider.

Note: the integration spec shows that the first exception thrown in `PoorlyBehavingErrorHandler` prevents subsequent handlers from running including, in the incident in the post-mortem above, the `Pwwka::ErrorHandlers::NackAndRequeueOnce` and `Pwwka::ErrorHandlers::Crash` handlers.