### PR TITLE
Add support for multiple routing keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,7 +211,7 @@ It requires some environment variables to work:
 
 * `HANDLER_KLASS` (required) refers to the class you have to write in your app (equivalent to a `job` in Resque)
 * `QUEUE_NAME` (required) we must use named queues - see below
-* `ROUTING_KEY` (optional) defaults to `#.#` (all messages)
+* `ROUTING_KEY` (optional) comma separated list of routing keys (e.g. `foo.bar.*,foo.baz.*`).  defaults to `#.#` (all messages)
 * `PREFETCH` (optional) sets a [prefetch value](http://rubybunny.info/articles/queues.html#qos__prefetching_messages) for the subscriber
 
 You'll also need to bring the Rake task into your app.  For Rails, you'll need to edit the top-level `Rakefile`:

--- a/lib/pwwka/receiver.rb
+++ b/lib/pwwka/receiver.rb
@@ -51,7 +51,7 @@ module Pwwka
     def topic_queue
       @topic_queue ||= begin
         queue = channel.queue(queue_name, durable: true, arguments: {})
-        queue.bind(topic_exchange, routing_key: routing_key)
+        routing_key.split(',').each { |k| queue.bind(topic_exchange, routing_key: k) }
         queue
       end
     end

--- a/spec/integration/send_and_receive_spec.rb
+++ b/spec/integration/send_and_receive_spec.rb
@@ -19,6 +19,7 @@ describe "sending and receiving messages", :integration do
 
       [AllReceiver                  , "all_receiver_pwwkatesting"             , "#"]                 ,
       [FooReceiver                  , "foo_receiver_pwwkatesting"             , "pwwka.testing.foo"] ,
+      [MultiRoutingReceived         , "multi_routing_receiver_pwwkatesting"   , "pwwka.testing.bar,pwwka.testing.foo"] ,
       [OtherFooReceiver             , "other_foo_receiver_pwwkatesting"       , "pwwka.testing.foo"] ,
       [Pwwka::QueueResqueJobHandler , "queue_resque_job_handler_pwwkatesting" , "#" ]                ,
 
@@ -27,6 +28,7 @@ describe "sending and receiving messages", :integration do
     end
     AllReceiver.reset!
     FooReceiver.reset!
+    MultiRoutingReceived.reset!
     OtherFooReceiver.reset!
     clear_queue(:delayed)
     clear_queue(MyTestJob)
@@ -46,6 +48,7 @@ describe "sending and receiving messages", :integration do
 
       expect(AllReceiver.messages_received.size).to eq(1)
       expect(FooReceiver.messages_received.size).to eq(1)
+      expect(MultiRoutingReceived.messages_received.size).to eq(1)
       expect(OtherFooReceiver.messages_received.size).to eq(1)
       @testing_setup.queues.each do |queue|
         expect(queue.message_count).to eq(0)
@@ -58,6 +61,7 @@ describe "sending and receiving messages", :integration do
 
       expect(AllReceiver.messages_received.size).to eq(1)
       expect(FooReceiver.messages_received.size).to eq(0)
+      expect(MultiRoutingReceived.messages_received.size).to eq(1)
       expect(OtherFooReceiver.messages_received.size).to eq(0)
       @testing_setup.queues.each do |queue|
         expect(queue.message_count).to eq(0)
@@ -200,11 +204,13 @@ describe "sending and receiving messages", :integration do
 
     expect(AllReceiver.messages_received.size).to eq(0)
     expect(FooReceiver.messages_received.size).to eq(0)
+    expect(MultiRoutingReceived.messages_received.size).to eq(0)
     expect(OtherFooReceiver.messages_received.size).to eq(0)
 
     allow_receivers_to_process_queues(5_000)
     expect(AllReceiver.messages_received.size).to eq(1)
     expect(FooReceiver.messages_received.size).to eq(1)
+    expect(MultiRoutingReceived.messages_received.size).to eq(1)
     expect(OtherFooReceiver.messages_received.size).to eq(1)
   end
 
@@ -240,5 +246,7 @@ describe "sending and receiving messages", :integration do
   class FooReceiver < AllReceiver
   end
   class OtherFooReceiver < AllReceiver
+  end
+  class MultiRoutingReceived < AllReceiver
   end
 end


### PR DESCRIPTION
I extended the existing ROUTING_KEY option to handle a list of comma
separated routing keys.  Right now for sku service, we're manually going
throught the webconsole to add more routing keys to the queue.  This is
not only tedious, but creates opportunity for confusion since the value
of the `ROUTING_KEY` passed to the rake task doesn't tell the whole
story of which messages a handler will recieve.

This change is backwards compatible, so should be safe to release as a
minor version bump.