### PR TITLE
Allow base log level to be configurable

### DIFF
--- a/lib/pwwka/configuration.rb
+++ b/lib/pwwka/configuration.rb
@@ -8,6 +8,7 @@ module Pwwka
     attr_accessor :topic_exchange_name
     attr_accessor :delayed_exchange_name
     attr_accessor :logger
+    attr_accessor :log_level
     attr_accessor :options
     attr_accessor :async_job_klass
     attr_accessor :send_message_resque_backoff_strategy
@@ -21,6 +22,7 @@ module Pwwka
       @topic_exchange_name   = "pwwka.topics.#{Pwwka.environment}"
       @delayed_exchange_name = "pwwka.delayed.#{Pwwka.environment}"
       @logger                = MonoLogger.new(STDOUT)
+      @log_level             = :info
       @options               = {}
       @send_message_resque_backoff_strategy = [5,                  #intermittent glitch?
                                                60,                 # quick interruption

--- a/lib/pwwka/logging.rb
+++ b/lib/pwwka/logging.rb
@@ -16,7 +16,7 @@ module Pwwka
     }
 
     def logf(format,params)
-      level = params.delete(:at) || :info
+      level = params.delete(:at) || Pwwka.configuration.log_level
       params[:payload] = params["payload"] if params["payload"]
       params[:payload] = "[omitted]" if params[:payload] && LEVELS[Pwwka.configuration.payload_logging.to_sym] > LEVELS[level.to_sym]
       message = format % params

--- a/spec/unit/logging_spec.rb
+++ b/spec/unit/logging_spec.rb
@@ -25,6 +25,7 @@ describe Pwwka::Logging do
 
     before do
       @original_logger = Pwwka.configuration.logger
+      @original_log_level = Pwwka.configuration.log_level
       Pwwka.configuration.logger = logger
       allow(logger).to receive(:info)
       allow(logger).to receive(:error)
@@ -32,8 +33,23 @@ describe Pwwka::Logging do
 
     after do
       Pwwka.configuration.logger = @original_logger
+      Pwwka.configuration.log_level = @original_log_level
       Pwwka.configuration.payload_logging = @original_payload_logging
     end
+
+    it "logs a printf-style string at info" do
+      ForLogging.logf("This is %{test} some %{data}", test: "a test of", data: "data and stuff", ignored: :hopefully)
+      expect(logger).to have_received(:info).with("This is a test of some data and stuff")
+    end
+
+    it "logs at a different level if configured to do so" do
+      Pwwka.configuration.log_level = :debug
+      allow(logger).to receive(:debug)
+
+      ForLogging.logf("This is %{test} some %{data}", test: "a test of", data: "data and stuff", ignored: :hopefully)
+      expect(logger).to have_received(:debug).with("This is a test of some data and stuff")
+    end
+
     it "logs a printf-style string at info" do
       ForLogging.logf("This is %{test} some %{data}", test: "a test of", data: "data and stuff", ignored: :hopefully)
       expect(logger).to have_received(:info).with("This is a test of some data and stuff")


### PR DESCRIPTION
I have a producer that generates large numbers of messages, resulting in a lot of log activity during normal operations. I'd like to be able to log from other components at `info` without producing so much log volume. This patch will allow me to set the log level to `debug` so I can switch on the detailed logging when I need it.