### PR TITLE
Add error to transmitter error log

### DIFF
--- a/lib/pwwka/transmitter.rb
+++ b/lib/pwwka/transmitter.rb
@@ -63,7 +63,7 @@ module Pwwka
       true
     rescue => e
 
-      logf "ERROR Transmitting Message on %{routing_key} -> %{payload}", routing_key: routing_key, payload: payload, at: :error
+      logf "ERROR %{error} Transmitting Message on %{routing_key} -> %{payload}", error: e, routing_key: routing_key, payload: payload, at: :error
 
       case on_error
 

--- a/lib/pwwka/transmitter.rb
+++ b/lib/pwwka/transmitter.rb
@@ -63,7 +63,7 @@ module Pwwka
       true
     rescue => e
 
-      logf "ERROR %{error} Transmitting Message on %{routing_key} -> %{payload}", error: e, routing_key: routing_key, payload: payload, at: :error
+      logf "ERROR Transmitting Message on %{routing_key} -> %{payload} : %{error}", routing_key: routing_key, payload: payload, error: e, at: :error
 
       case on_error
 

--- a/spec/unit/transmitter_spec.rb
+++ b/spec/unit/transmitter_spec.rb
@@ -235,16 +235,16 @@ describe Pwwka::Transmitter do
       end
     end
     context "when there's an error" do
-      let(:error) { "OH NOES" }
       before do
-        allow_any_instance_of(described_class).to receive(:send_message!).and_raise(error)
+        allow_any_instance_of(described_class).to receive(:send_message!).and_raise("OH NOES")
       end
       it "logs the error" do
         begin
           described_class.send_message!(payload,routing_key)
         rescue => ex
         end
-        expect(logger).to have_received(:error).with(/ERROR #{error} Transmitting Message on #{routing_key} ->/)
+        expect(logger).to have_received(:error).with(/ERROR Transmitting Message on #{routing_key} ->/)
+        expect(logger).to have_received(:error).with(/OH NOES/)
       end
       context "on_error: :ignore" do
         it "ignores the error" do
@@ -292,16 +292,16 @@ describe Pwwka::Transmitter do
       end
     end
     context "when there's an error" do
-      let(:error) { "OH NOES" }
       before do
-        allow_any_instance_of(described_class).to receive(:send_message!).and_raise(error)
+        allow_any_instance_of(described_class).to receive(:send_message!).and_raise("OH NOES")
       end
       it "logs the error" do
         begin
           described_class.send_message_safely(payload,routing_key)
         rescue => ex
         end
-        expect(logger).to have_received(:error).with(/ERROR #{error} Transmitting Message on #{routing_key} ->/)
+        expect(logger).to have_received(:error).with(/ERROR Transmitting Message on #{routing_key} ->/)
+        expect(logger).to have_received(:error).with(/OH NOES/)
       end
       it "ignores the error" do
         expect {

--- a/spec/unit/transmitter_spec.rb
+++ b/spec/unit/transmitter_spec.rb
@@ -235,15 +235,16 @@ describe Pwwka::Transmitter do
       end
     end
     context "when there's an error" do
+      let(:error) { "OH NOES" }
       before do
-        allow_any_instance_of(described_class).to receive(:send_message!).and_raise("OH NOES")
+        allow_any_instance_of(described_class).to receive(:send_message!).and_raise(error)
       end
       it "logs the error" do
         begin
           described_class.send_message!(payload,routing_key)
         rescue => ex
         end
-        expect(logger).to have_received(:error).with(/ERROR Transmitting Message on #{routing_key} ->/)
+        expect(logger).to have_received(:error).with(/ERROR #{error} Transmitting Message on #{routing_key} ->/)
       end
       context "on_error: :ignore" do
         it "ignores the error" do
@@ -291,15 +292,16 @@ describe Pwwka::Transmitter do
       end
     end
     context "when there's an error" do
+      let(:error) { "OH NOES" }
       before do
-        allow_any_instance_of(described_class).to receive(:send_message!).and_raise("OH NOES")
+        allow_any_instance_of(described_class).to receive(:send_message!).and_raise(error)
       end
       it "logs the error" do
         begin
           described_class.send_message_safely(payload,routing_key)
         rescue => ex
         end
-        expect(logger).to have_received(:error).with(/ERROR Transmitting Message on #{routing_key} ->/)
+        expect(logger).to have_received(:error).with(/ERROR #{error} Transmitting Message on #{routing_key} ->/)
       end
       it "ignores the error" do
         expect {


### PR DESCRIPTION
This adds the error message to the transmitter error log. This can help with debugging why an error occured even if it was retried successfully.