### PR TITLE
Added option to set a connection_name

### DIFF
--- a/lib/pwwka/channel_connector.rb
+++ b/lib/pwwka/channel_connector.rb
@@ -8,9 +8,10 @@ module Pwwka
     # The channel_connector starts the connection to the message_bus
     # so it should only be instantiated by a method that has a strategy
     # for closing the connection
-    def initialize(prefetch: nil)
+    def initialize(prefetch: nil, connection_name: nil)
       @configuration     = Pwwka.configuration
       connection_options = {automatically_recover: false}.merge(configuration.options)
+      connection_options = {client_properties: {connection_name: connection_name}}.merge(connection_options) if connection_name
       @connection        = Bunny.new(configuration.rabbit_mq_host,
                                   connection_options)
       @connection.start

--- a/lib/pwwka/receiver.rb
+++ b/lib/pwwka/receiver.rb
@@ -12,7 +12,7 @@ module Pwwka
     def initialize(queue_name, routing_key, prefetch: Pwwka.configuration.default_prefetch)
       @queue_name        = queue_name
       @routing_key       = routing_key
-      @channel_connector = ChannelConnector.new(prefetch: prefetch)
+      @channel_connector = ChannelConnector.new(prefetch: prefetch, connection_name: "s: #{queue_name}")
       @channel           = @channel_connector.channel
       @topic_exchange    = @channel_connector.topic_exchange
     end

--- a/lib/pwwka/receiver.rb
+++ b/lib/pwwka/receiver.rb
@@ -12,7 +12,7 @@ module Pwwka
     def initialize(queue_name, routing_key, prefetch: Pwwka.configuration.default_prefetch)
       @queue_name        = queue_name
       @routing_key       = routing_key
-      @channel_connector = ChannelConnector.new(prefetch: prefetch, connection_name: "s: #{queue_name}")
+      @channel_connector = ChannelConnector.new(prefetch: prefetch, connection_name: "c: #{queue_name}")
       @channel           = @channel_connector.channel
       @topic_exchange    = @channel_connector.topic_exchange
     end

--- a/lib/pwwka/transmitter.rb
+++ b/lib/pwwka/transmitter.rb
@@ -26,7 +26,7 @@ module Pwwka
     attr_reader :channel_connector
 
     def initialize
-      @channel_connector = ChannelConnector.new
+      @channel_connector = ChannelConnector.new(connection_name: "p: #{Pwwka.configuration.app_id}")
     end
 
     # Send an important message that must go through.  This method allows any raised exception 

--- a/spec/unit/channel_connector_spec.rb
+++ b/spec/unit/channel_connector_spec.rb
@@ -29,7 +29,7 @@ describe Pwwka::ChannelConnector do
 
     it "sets a connection_name if configured to do so" do
       expect(Bunny).to receive(:new).with(
-        "amqp://guest:guest@localhost:10001", 
+        /amqp:\/\/guest:guest@localhost:/, 
         {:client_properties=>{:connection_name=>"test_connection"},
          :automatically_recover=>false,
          :allow_delayed=>true})
@@ -39,7 +39,7 @@ describe Pwwka::ChannelConnector do
 
     it "only contains default options if none provided" do
       expect(Bunny).to receive(:new).with(
-        "amqp://guest:guest@localhost:10001", 
+        /amqp:\/\/guest:guest@localhost:/, 
         {:automatically_recover=>false, :allow_delayed=>true})
 
       described_class.new

--- a/spec/unit/channel_connector_spec.rb
+++ b/spec/unit/channel_connector_spec.rb
@@ -26,6 +26,25 @@ describe Pwwka::ChannelConnector do
 
       described_class.new
     end
+
+    it "sets a connection_name if configured to do so" do
+      expect(Bunny).to receive(:new).with(
+        "amqp://guest:guest@localhost:10001", 
+        {:client_properties=>{:connection_name=>"test_connection"},
+         :automatically_recover=>false,
+         :allow_delayed=>true})
+
+      described_class.new(connection_name: "test_connection")
+    end
+
+    it "only contains default options if none provided" do
+      expect(Bunny).to receive(:new).with(
+        "amqp://guest:guest@localhost:10001", 
+        {:automatically_recover=>false, :allow_delayed=>true})
+
+      described_class.new
+    end
+
   end
 
   describe "raise_if_delayed_not_allowed" do

--- a/spec/unit/receiver_spec.rb
+++ b/spec/unit/receiver_spec.rb
@@ -1,0 +1,17 @@
+require 'spec_helper.rb'
+
+describe Pwwka::Receiver do
+  describe "#new" do 
+    let(:channel_connector) { double(Pwwka::ChannelConnector)}
+
+    before do
+      allow(Pwwka::ChannelConnector).to receive(:new).with(prefetch: nil, connection_name: "c: test_queue_name").and_return(channel_connector)
+      allow(channel_connector).to receive(:channel)
+      allow(channel_connector).to receive(:topic_exchange)
+    end
+
+    it "should set the connection_name" do
+      Pwwka::Receiver.new("test_queue_name", "test.routing.key")
+    end
+  end
+end

--- a/spec/unit/transmitter_spec.rb
+++ b/spec/unit/transmitter_spec.rb
@@ -20,7 +20,7 @@ describe Pwwka::Transmitter do
     allow(logger).to receive(:info)
     allow(logger).to receive(:warn)
     allow(logger).to receive(:error)
-    allow(Pwwka::ChannelConnector).to receive(:new).and_return(channel_connector)
+    allow(Pwwka::ChannelConnector).to receive(:new).with(connection_name: "p: MyAwesomeApp").and_return(channel_connector)
     allow(channel_connector).to receive(:connection_close)
     allow(topic_exchange).to receive(:publish)
     allow(delayed_exchange).to receive(:publish)


### PR DESCRIPTION
# Problem
It would be helpful to see a friendly name for a connection when viewing the connections in the RabbitMQ management UI.

# Solution
Add the option to set a connection name when creating a connection.

# Notes
For consumers, this approach is automatically setting the connection name to the value of the queue name that the is being consumed. `c: queue_name_here` Example from management UI:
![screen shot 2018-12-07 at 5 19 03 pm](https://user-images.githubusercontent.com/753106/49675580-51174600-fa44-11e8-82e4-8378e9e99ee6.png)


For publishers, automatically creating a connection name is more difficult without requiring the host application to send along a name.  Still investigating the best approach here.