### PR TITLE
Ensure connections are closed

### DIFF
--- a/lib/pwwka/receiver.rb
+++ b/lib/pwwka/receiver.rb
@@ -47,6 +47,7 @@ module Pwwka
       rescue Interrupt => _
         # TODO: trap TERM within channel.work_pool
         info "Interrupting queue #{queue_name} subscriber safely"
+      ensure
         receiver.channel_connector.connection_close
       end
       return receiver

--- a/lib/pwwka/transmitter.rb
+++ b/lib/pwwka/transmitter.rb
@@ -121,10 +121,11 @@ module Pwwka
       )
       logf "START Transmitting Message on id[%{id}] %{routing_key} -> %{payload}", id: publish_options.message_id, routing_key: routing_key, payload: payload
       channel_connector.topic_exchange.publish(payload.to_json, publish_options.to_h)
-      channel_connector.connection_close
       # if it gets this far it has succeeded
       logf "END Transmitting Message on id[%{id}] %{routing_key} -> %{payload}", id: publish_options.message_id, routing_key: routing_key, payload: payload
       true
+    ensure
+      channel_connector.connection_close
     end
 
 
@@ -140,10 +141,11 @@ module Pwwka
       logf "START Transmitting Delayed Message on id[%{id}] %{routing_key} -> %{payload}", id: publish_options.message_id, routing_key: routing_key, payload: payload
       channel_connector.create_delayed_queue
       channel_connector.delayed_exchange.publish(payload.to_json,publish_options.to_h)
-      channel_connector.connection_close
       # if it gets this far it has succeeded
       logf "END Transmitting Delayed Message on id[%{id}] %{routing_key} -> %{payload}", id: publish_options.message_id, routing_key: routing_key, payload: payload
       true
+    ensure
+      channel_connector.connection_close
     end
 
   end

--- a/spec/unit/receiver_spec.rb
+++ b/spec/unit/receiver_spec.rb
@@ -35,5 +35,12 @@ describe Pwwka::Receiver do
       begin; subject; rescue; end
       expect(channel_connector).to have_received(:connection_close)
     end
+
+    it 'logs on interrupt' do
+      allow(handler_klass).to receive(:handle!).and_raise(Interrupt)
+      allow(described_class).to receive(:info)
+      begin; subject; rescue; end
+      expect(described_class).to have_received(:info).with(/Interrupting queue #{queue_name}/)
+    end
   end
 end

--- a/spec/unit/receiver_spec.rb
+++ b/spec/unit/receiver_spec.rb
@@ -1,17 +1,39 @@
 require 'spec_helper.rb'
 
 describe Pwwka::Receiver do
-  describe "#new" do 
-    let(:channel_connector) { double(Pwwka::ChannelConnector)}
+  describe "#new" do
+    let(:handler_klass) { double('HandlerKlass') }
+    let(:channel_connector) { double(Pwwka::ChannelConnector, topic_exchange: topic_exchange, channel: channel)}
+    let(:topic_exchange) { double("topic exchange") }
+    let(:channel) { double('channel', queue: queue) }
+    let(:queue) { double('queue') }
+    let(:queue_name) { 'test_queue_name' }
+
+    subject {
+      described_class.subscribe(
+        handler_klass,
+        queue_name
+      )
+    }
 
     before do
-      allow(Pwwka::ChannelConnector).to receive(:new).with(prefetch: nil, connection_name: "c: test_queue_name").and_return(channel_connector)
-      allow(channel_connector).to receive(:channel)
-      allow(channel_connector).to receive(:topic_exchange)
+      allow(Pwwka::ChannelConnector).to receive(:new).and_return(channel_connector)
+      allow(handler_klass).to receive(:handle!)
+      allow(channel_connector).to receive(:connection_close)
+      allow(queue).to receive(:bind)
+      allow(queue).to receive(:subscribe).and_yield({}, {}, '{}')
     end
 
-    it "should set the connection_name" do
-      Pwwka::Receiver.new("test_queue_name", "test.routing.key")
+    it 'sets the correct connection_name' do
+      subject
+      expect(Pwwka::ChannelConnector).to have_received(:new).with(prefetch: nil, connection_name: "c: #{queue_name}")
+    end
+
+    it 'closes the conenction on an error' do
+      error = 'oh no'
+      allow(handler_klass).to receive(:handle!).and_raise(error)
+      begin; subject; rescue; end
+      expect(channel_connector).to have_received(:connection_close)
     end
   end
 end

--- a/spec/unit/transmitter_spec.rb
+++ b/spec/unit/transmitter_spec.rb
@@ -327,8 +327,25 @@ describe Pwwka::Transmitter do
       expect(channel_connector).to have_received(:connection_close)
     end
 
-    context "with only basic required arguments" do
+    context 'when an error is raised' do
+      subject { transmitter.send_message!(payload,routing_key) }
+      let(:error) { 'oh no' }
 
+      before do
+        allow(topic_exchange).to receive(:publish).and_raise(error)
+      end
+
+      it 'should raise the error' do
+        expect { subject } .to raise_error(error)
+      end
+
+      it 'should close the channel connector' do
+        begin; subject; rescue; end
+        expect(channel_connector).to have_received(:connection_close)
+      end
+    end
+
+    context "with only basic required arguments" do
       before do
         transmitter.send_message!(payload,routing_key)
       end
@@ -337,6 +354,7 @@ describe Pwwka::Transmitter do
         let(:exchange) { topic_exchange }
       end
     end
+
     context "with everything overridden" do
       before do
         transmitter.send_message!(
@@ -367,6 +385,24 @@ describe Pwwka::Transmitter do
       it "creates the delayed queue" do
         transmitter.send_delayed_message!(payload,routing_key)
         expect(channel_connector).to have_received(:create_delayed_queue)
+      end
+
+      context 'when an error is raised' do
+        subject { transmitter.send_delayed_message!(payload,routing_key) }
+        let(:error) { 'oh no' }
+
+        before do
+          allow(delayed_exchange).to receive(:publish).and_raise(error)
+        end
+
+        it 'should raise the error' do
+          expect { subject } .to raise_error(error)
+        end
+
+        it 'should close the channel connector' do
+          begin; subject; rescue; end
+          expect(channel_connector).to have_received(:connection_close)
+        end
       end
 
       context "with only basic required arguments" do


### PR DESCRIPTION
# Problem

Sometimes errors can happen during the transmission of messages. In those cases the code underneath is not run & connections can not be closed properly.

# Solution

Close the connection always with `ensure`!