### PR TITLE
Added configuration to allow for using process name in connection_name

### DIFF
--- a/lib/pwwka/configuration.rb
+++ b/lib/pwwka/configuration.rb
@@ -33,7 +33,7 @@ module Pwwka
       @async_job_klass = Pwwka::SendMessageAsyncJob
       @default_prefetch = nil
       @receive_raw_payload = false
-      @process_name = ""
+      @process_name = $0
     end
 
     def keep_alive_on_handler_klass_exceptions?

--- a/lib/pwwka/configuration.rb
+++ b/lib/pwwka/configuration.rb
@@ -13,6 +13,7 @@ module Pwwka
     attr_accessor :async_job_klass
     attr_accessor :send_message_resque_backoff_strategy
     attr_accessor :default_prefetch
+    attr_accessor :process_name
     attr_reader   :requeue_on_error
     attr_writer   :app_id
     attr_writer   :error_handling_chain
@@ -32,6 +33,7 @@ module Pwwka
       @async_job_klass = Pwwka::SendMessageAsyncJob
       @default_prefetch = nil
       @receive_raw_payload = false
+      @process_name = ""
     end
 
     def keep_alive_on_handler_klass_exceptions?

--- a/lib/pwwka/receiver.rb
+++ b/lib/pwwka/receiver.rb
@@ -12,7 +12,7 @@ module Pwwka
     def initialize(queue_name, routing_key, prefetch: Pwwka.configuration.default_prefetch)
       @queue_name        = queue_name
       @routing_key       = routing_key
-      @channel_connector = ChannelConnector.new(prefetch: prefetch, connection_name: "c: #{queue_name}")
+      @channel_connector = ChannelConnector.new(prefetch: prefetch, connection_name: "c: #{Pwwka.configuration.app_id} #{Pwwka.configuration.process_name}".strip)
       @channel           = @channel_connector.channel
       @topic_exchange    = @channel_connector.topic_exchange
     end

--- a/lib/pwwka/transmitter.rb
+++ b/lib/pwwka/transmitter.rb
@@ -26,7 +26,7 @@ module Pwwka
     attr_reader :channel_connector
 
     def initialize
-      @channel_connector = ChannelConnector.new(connection_name: "p: #{Pwwka.configuration.app_id}")
+      @channel_connector = ChannelConnector.new(connection_name: "p: #{Pwwka.configuration.app_id} #{Pwwka.configuration.process_name}".strip)
     end
 
     # Send an important message that must go through.  This method allows any raised exception 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -35,6 +35,7 @@ RSpec.configure do |config|
       c.requeue_on_error           = false
       c.rabbit_mq_host             = "amqp://guest:guest@localhost:#{test_configuration.rabbit_port}"
       c.app_id                     = "MyAwesomeApp"
+      c.process_name               = "my_awesome_process"
 
       unless ENV["SHOW_PWWKA_LOG"] == "true"
         c.logger = MonoLogger.new("/dev/null")

--- a/spec/unit/receiver_spec.rb
+++ b/spec/unit/receiver_spec.rb
@@ -26,7 +26,7 @@ describe Pwwka::Receiver do
 
     it 'sets the correct connection_name' do
       subject
-      expect(Pwwka::ChannelConnector).to have_received(:new).with(prefetch: nil, connection_name: "c: #{queue_name}")
+      expect(Pwwka::ChannelConnector).to have_received(:new).with(prefetch: nil, connection_name: "c: MyAwesomeApp my_awesome_process")
     end
 
     it 'closes the conenction on an error' do

--- a/spec/unit/transmitter_spec.rb
+++ b/spec/unit/transmitter_spec.rb
@@ -20,7 +20,7 @@ describe Pwwka::Transmitter do
     allow(logger).to receive(:info)
     allow(logger).to receive(:warn)
     allow(logger).to receive(:error)
-    allow(Pwwka::ChannelConnector).to receive(:new).with(connection_name: "p: MyAwesomeApp").and_return(channel_connector)
+    allow(Pwwka::ChannelConnector).to receive(:new).with(connection_name: "p: MyAwesomeApp my_awesome_process").and_return(channel_connector)
     allow(channel_connector).to receive(:connection_close)
     allow(topic_exchange).to receive(:publish)
     allow(delayed_exchange).to receive(:publish)


### PR DESCRIPTION
# Problem
It's hard to tell exactly what the process/worker is for a given connection

# Solution
Allow the process name to be set in configuration and included in the `connect_name`