### PR TITLE
Removed $0 as default process name

### DIFF
--- a/lib/pwwka/configuration.rb
+++ b/lib/pwwka/configuration.rb
@@ -33,7 +33,7 @@ module Pwwka
       @async_job_klass = Pwwka::SendMessageAsyncJob
       @default_prefetch = nil
       @receive_raw_payload = false
-      @process_name = $0
+      @process_name = ""
     end
 
     def keep_alive_on_handler_klass_exceptions?


### PR DESCRIPTION
# Problem
@FreekingDean raised the concern about usin `$0` as a default process name value since it exposes details about the underlying system configuration.

# Solution
Set the default to an empty string instead.