### PR TITLE
Add begin/rescue around SendMessageAsyncSidekiqJob for apps that don'…

### DIFF
--- a/lib/pwwka.rb
+++ b/lib/pwwka.rb
@@ -31,7 +31,4 @@ require 'pwwka/message_queuer'
 require 'pwwka/error_handlers'
 require 'pwwka/configuration'
 require 'pwwka/send_message_async_job'
-begin  # optional dependency
-  require 'pwwka/send_message_async_sidekiq_job'
-rescue LoadError
-end
+require 'pwwka/send_message_async_sidekiq_job'

--- a/lib/pwwka/send_message_async_sidekiq_job.rb
+++ b/lib/pwwka/send_message_async_sidekiq_job.rb
@@ -1,29 +1,35 @@
-require 'sidekiq'
+begin
+  require 'sidekiq'
+rescue LoadError
+end
 
 module Pwwka
   class SendMessageAsyncSidekiqJob
-    include Sidekiq::Worker
-    extend Pwwka::Logging
+    begin
+      include Sidekiq::Worker
+      extend Pwwka::Logging
 
-    sidekiq_options queue: 'pwwka_send_message_async', retry: 3
+      sidekiq_options queue: 'pwwka_send_message_async', retry: 3
 
-    def perform(payload, routing_key, options = {})
-      type = options["type"]
-      message_id = options["message_id"] || "auto_generate"
-      headers = options["headers"]
+      def perform(payload, routing_key, options = {})
+        type = options["type"]
+        message_id = options["message_id"] || "auto_generate"
+        headers = options["headers"]
 
-      logger.info("Sending message async #{routing_key}, #{payload}")
+        logger.info("Sending message async #{routing_key}, #{payload}")
 
-      message_id = message_id.to_sym if message_id == "auto_generate"
+        message_id = message_id.to_sym if message_id == "auto_generate"
 
-      Pwwka::Transmitter.send_message!(
-        payload,
-        routing_key,
-        type: type,
-        message_id: message_id,
-        headers: headers,
-        on_error: :raise,
-      )
+        Pwwka::Transmitter.send_message!(
+          payload,
+          routing_key,
+          type: type,
+          message_id: message_id,
+          headers: headers,
+          on_error: :raise,
+        )
+      end
+    rescue NameError
     end
   end
 end

--- a/lib/pwwka/transmitter.rb
+++ b/lib/pwwka/transmitter.rb
@@ -3,7 +3,6 @@ require_relative "publish_options"
 begin  # optional dependency
   require 'resque'
   require 'resque-retry'
-  require 'sidekiq'
 rescue LoadError
 end
 


### PR DESCRIPTION
…t have sidekiq

The last release of Pwwka had a breaking change for apps that are on Resque because even though I was defensive against trying to load Sidekiq [here](https://github.com/stitchfix/pwwka/blob/master/lib/pwwka.rb#L34-L36), that wasn't sufficient, since `Pwwka::SendMessageAsyncSidekiqJob` is also loaded [here](https://github.com/stitchfix/pwwka/blob/master/lib/pwwka/configuration.rb#L151-L156). I was able to quickly yank that broken version of the gem, but I want to get a fix out there ASAP. 

The solution I came up with was to remove the begin/rescue block from lib/pwwka.rb and instead, but it in the source of the dependency issue, in the Sidekiq job file. This way, the Sidekiq job will only be loaded if sidekiq is available, otherwise it will return null.