### PR TITLE
Logging errors that occur on a channel

### DIFF
--- a/lib/pwwka/channel_connector.rb
+++ b/lib/pwwka/channel_connector.rb
@@ -26,6 +26,9 @@ module Pwwka
 
       begin
         @channel = @connection.create_channel
+        @channel.on_error do |instance, method|
+          logf "ERROR On RabbitMQ channel: #{instance}, #{method}"
+        end
       rescue => e
         logf "ERROR Opening RabbitMQ channel", error: e
         @connection.close if @connection


### PR DESCRIPTION
# Problem
If an error occurs on a channel we aren't notified of it

# Solution
Start by logging them so we can see the types and figure out how to appropriately handle them