### PR TITLE
Logging errors that occur on a channel

### DIFF
--- a/lib/pwwka/channel_connector.rb
+++ b/lib/pwwka/channel_connector.rb
@@ -19,7 +19,8 @@ module Pwwka
         @connection = Bunny.new(configuration.rabbit_mq_host, connection_options)
         @connection.start
       rescue => e
-        logf "ERROR Connecting to RabbitMQ", error: e
+        logf "ERROR Connecting to RabbitMQ: #{e}", at: :error
+
         @connection.close if @connection
         raise e
       end
@@ -30,7 +31,7 @@ module Pwwka
           logf "ERROR On RabbitMQ channel: #{method.inspect}"
         end
       rescue => e
-        logf "ERROR Opening RabbitMQ channel", error: e
+        logf "ERROR Opening RabbitMQ channel: #{e}", at: :error
         @connection.close if @connection
         raise e
       end
@@ -84,14 +85,13 @@ module Pwwka
       begin
         channel.close
       rescue => e
-        logf "ERROR Closing RabbitMQ channel", error: e
-        raise e
+        logf "ERROR Closing RabbitMQ channel: #{e}", at: :error
       end
 
       begin
         connection.close
       rescue => e
-        logf "ERROR Closing connection to RabbitMQ", error: e
+        logf "ERROR Closing connection to RabbitMQ: #{e}", at: :error
         raise e
       end
     end

--- a/lib/pwwka/channel_connector.rb
+++ b/lib/pwwka/channel_connector.rb
@@ -26,6 +26,9 @@ module Pwwka
 
       begin
         @channel = @connection.create_channel
+        @channel.on_error do |ch, method|
+          logf "ERROR On RabbitMQ channel: #{method.inspect}"
+        end
       rescue => e
         logf "ERROR Opening RabbitMQ channel", error: e
         @connection.close if @connection

--- a/spec/unit/channel_connector_spec.rb
+++ b/spec/unit/channel_connector_spec.rb
@@ -14,12 +14,18 @@ describe Pwwka::ChannelConnector do
       allow(bunny_session).to receive(:start)
       allow(bunny_session).to receive(:close)
       allow(bunny_session).to receive(:create_channel).and_return(bunny_channel)
+      allow(bunny_channel).to receive(:on_error)
     end
 
     it "sets a prefetch value if configured to do so" do
       expect(bunny_channel).to receive(:prefetch).with(10)
 
       described_class.new(prefetch: 10)
+    end
+
+    it "sets an on_error handler" do
+      expect(bunny_channel).to receive(:on_error)
+      described_class.new
     end
 
     it "does not set a prefetch value unless configured" do
@@ -67,10 +73,14 @@ describe Pwwka::ChannelConnector do
   end
 
   describe "raise_if_delayed_not_allowed" do
+    let(:bunny_channel) { instance_double(Bunny::Channel) }
+
     before do
       allow(Bunny).to receive(:new).and_return(bunny_session)
       allow(bunny_session).to receive(:start)
-      allow(bunny_session).to receive(:create_channel)
+      allow(bunny_session).to receive(:close)
+      allow(bunny_session).to receive(:create_channel).and_return(bunny_channel)
+      allow(bunny_channel).to receive(:on_error)
       @default_allow_delayed = Pwwka.configuration.options[:allow_delayed]
     end
 


### PR DESCRIPTION
# Problems
Errors can occur on channels for methods that do not return a response and these error go un-reported.  

# Solution
Log the errors for visibility.  Details on API being used: https://github.com/ruby-amqp/bunny/blob/master/ChangeLog.md#bunnychannelon_error
