### PR TITLE
Raise on channel close

### DIFF
--- a/lib/pwwka/channel_connector.rb
+++ b/lib/pwwka/channel_connector.rb
@@ -82,6 +82,7 @@ module Pwwka
         channel.close
       rescue => e
         logf "ERROR Closing RabbitMQ channel", error: e
+        raise e
       end
 
       begin


### PR DESCRIPTION
# Problem
It seems that not raising on channel close errors and then trying to close the connection is pushing the total run-time of the process past the rack timeout

# Solution
Go ahead and raise if `channel.close` errors out to match previous behavior