### PR TITLE
Persistent connection prep

### DIFF
--- a/lib/pwwka.rb
+++ b/lib/pwwka.rb
@@ -9,6 +9,10 @@ module Pwwka
       @configuration ||= Configuration.new
     end
 
+    def connections
+      ChannelConnector
+    end
+
     def environment
       ENV['RAILS_ENV'] || ENV['RACK_ENV'] || 'development'
     end

--- a/lib/pwwka/channel_connector.rb
+++ b/lib/pwwka/channel_connector.rb
@@ -7,6 +7,13 @@ module Pwwka
     attr_reader :configuration
     attr_reader :channel
 
+    def self.checkout(**kwargs, &block)
+      conn = new(**kwargs)
+      block.call(conn)
+    ensure
+      conn.connection_close if conn
+    end
+
     # The channel_connector starts the connection to the message_bus
     # so it should only be instantiated by a method that has a strategy
     # for closing the connection

--- a/lib/pwwka/receiver.rb
+++ b/lib/pwwka/receiver.rb
@@ -3,18 +3,11 @@ module Pwwka
 
     extend Pwwka::Logging
 
-    attr_reader :channel_connector
-    attr_reader :channel
-    attr_reader :topic_exchange
-    attr_reader :queue_name
-    attr_reader :routing_key
-
     def initialize(queue_name, routing_key, prefetch: Pwwka.configuration.default_prefetch)
-      @queue_name        = queue_name
-      @routing_key       = routing_key
-      @channel_connector = ChannelConnector.new(prefetch: prefetch, connection_name: "c: #{Pwwka.configuration.app_id} #{Pwwka.configuration.process_name}".strip)
-      @channel           = @channel_connector.channel
-      @topic_exchange    = @channel_connector.topic_exchange
+      @queue_name  = queue_name
+      @routing_key = routing_key
+      @prefetch    = prefetch
+      @connections = Pwwka.connections
     end
 
     def self.subscribe(handler_klass, queue_name,
@@ -23,10 +16,10 @@ module Pwwka
                        prefetch: Pwwka.configuration.default_prefetch,
                        payload_parser: Pwwka.configuration.payload_parser)
       raise "#{handler_klass.name} must respond to `handle!`" unless handler_klass.respond_to?(:handle!)
-      receiver  = new(queue_name, routing_key, prefetch: prefetch)
+      receiver = new(queue_name, routing_key, prefetch: prefetch)
       begin
         info "Receiving on #{queue_name}"
-        receiver.topic_queue.subscribe(manual_ack: true, block: block) do |delivery_info, properties, payload|
+        receiver.subscribe(manual_ack: true, block: block) do |delivery_info, properties, payload|
           begin
             payload = payload_parser.(payload)
             handler_klass.handle!(delivery_info, properties, payload)
@@ -47,18 +40,23 @@ module Pwwka
       rescue Interrupt => _
         # TODO: trap TERM within channel.work_pool
         info "Interrupting queue #{queue_name} subscriber safely"
-      ensure
-        receiver.channel_connector.connection_close
       end
       return receiver
     end
 
-    def topic_queue
-      @topic_queue ||= begin
+    def subscribe(**kwargs, &block)
+      connect do |connection|
+        @channel = connection.channel
+        @topic_exchange = connection.topic_exchange
         queue = channel.queue(queue_name, durable: true, arguments: {})
-        routing_key.split(',').each { |k| queue.bind(topic_exchange, routing_key: k) }
-        queue
+        routing_key.split(',').each do |k|
+          queue.bind(topic_exchange, routing_key: k)
+        end
+
+        queue.subscribe(**kwargs, &block)
       end
+    ensure
+      @channel = nil
     end
 
     def ack(delivery_tag)
@@ -73,15 +71,34 @@ module Pwwka
       channel.nack(delivery_tag, false, true)
     end
 
-    def drop_queue
-      topic_queue.purge
-      topic_queue.delete
+    def test_teardown
+      connect do |connection|
+        queue = connection.channel.queue(queue_name, durable: true, arguments: {})
+        queue.purge
+        queue.delete
+        topic_exchange.delete
+      end
     end
 
-    def test_teardown
-      drop_queue
-      topic_exchange.delete
-      channel_connector.connection_close
+    def drop_queue
+      connect do |connection|
+        queue = connection.channel.queue(queue_name, durable: true, arguments: {})
+        queue.purge
+        queue.delete
+      end
     end
+
+    private
+
+    attr_reader :channel_connector
+    attr_reader :channel
+    attr_reader :queue_name
+    attr_reader :routing_key
+    attr_reader :topic_exchange
+
+    def connect(&block)
+      @connections.checkout(prefetch: @prefetch, connection_name: "c: #{Pwwka.configuration.app_id} #{Pwwka.configuration.process_name}".strip, &block)
+    end
+
   end
 end

--- a/spec/integration/support/integration_test_setup.rb
+++ b/spec/integration/support/integration_test_setup.rb
@@ -30,11 +30,13 @@ class IntegrationTestSetup
   def channel_connector
     @channel_connector ||= Pwwka::ChannelConnector.new
   end
+
   def channel
-    channel_connector.channel
+    channel_connector.send(:channel)
   end
+
   def topic_exchange
-    channel_connector.topic_exchange
+    channel_connector.send(:topic_exchange)
   end
 
 end

--- a/spec/unit/receiver_spec.rb
+++ b/spec/unit/receiver_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper.rb'
 describe Pwwka::Receiver do
   describe "#new" do
     let(:handler_klass) { double('HandlerKlass') }
-    let(:channel_connector) { double(Pwwka::ChannelConnector, topic_exchange: topic_exchange, channel: channel)}
+    let(:channel_connector) { instance_double(Pwwka::ChannelConnector, topic_exchange: topic_exchange, channel: channel)}
     let(:topic_exchange) { double("topic exchange") }
     let(:channel) { double('channel', queue: queue) }
     let(:queue) { double('queue') }
@@ -27,13 +27,6 @@ describe Pwwka::Receiver do
     it 'sets the correct connection_name' do
       subject
       expect(Pwwka::ChannelConnector).to have_received(:new).with(prefetch: nil, connection_name: "c: MyAwesomeApp my_awesome_process")
-    end
-
-    it 'closes the conenction on an error' do
-      error = 'oh no'
-      allow(handler_klass).to receive(:handle!).and_raise(error)
-      begin; subject; rescue; end
-      expect(channel_connector).to have_received(:connection_close)
     end
 
     it 'logs on interrupt' do


### PR DESCRIPTION
This is a WIP in service of another branch I'm working on, which implements persistent (per-process) connections for Pwwka. This will probably change and be further refactored as I explore the changes necessary to make the persistent connector work. The goal of this particular PR is to contain structural/refactoring changes that are not expected to alter functionality.