### PR TITLE
Automatic persistent connections

### DIFF
--- a/lib/pwwka.rb
+++ b/lib/pwwka.rb
@@ -10,7 +10,8 @@ module Pwwka
     end
 
     def connections
-      ChannelConnector
+      #ChannelConnector
+      ConnectionRepository.instance
     end
 
     def environment
@@ -28,6 +29,7 @@ require 'active_support/hash_with_indifferent_access'
 require 'pwwka/version'
 require 'pwwka/logging'
 require 'pwwka/channel_connector'
+require 'pwwka/connection_repository'
 require 'pwwka/handling'
 require 'pwwka/receiver'
 require 'pwwka/transmitter'
@@ -36,3 +38,4 @@ require 'pwwka/error_handlers'
 require 'pwwka/configuration'
 require 'pwwka/send_message_async_job'
 require 'pwwka/send_message_async_sidekiq_job'
+

--- a/lib/pwwka/connection_repository.rb
+++ b/lib/pwwka/connection_repository.rb
@@ -1,0 +1,106 @@
+module Pwwka
+  class ConnectionRepository
+
+    def self.instance
+      unless !defined?(@current_pid) || @current_pid != Process.pid
+        # New process needs a new repository
+        @instance = nil
+      end
+      @instance ||= new
+    end
+
+    def self.reset!
+      if @instance
+        @instance.send(:disconnect!)
+      end
+      @instance = nil
+    end
+
+    def initialize
+      @thread_variable_name = :"pwwka_channel_#{object_id}"
+
+      connection_options = Pwwka.configuration.options.merge({
+        # Automatic recovery is necessary because the connection is retained
+        automatically_recover: true
+        # TODO: connection name
+      })
+      @connection = Bunny.new(Pwwka.configuration.rabbit_mq_host, connection_options)
+      @connection.start
+    end
+
+    def checkout(**_, &block)
+      block.call channel
+    end
+
+    def channel
+      Thread.current[@thread_variable_name] ||= Channel.new(@connection, Pwwka.configuration)
+    end
+
+    private
+
+    def disconnect!
+      @connection.close
+    end
+
+    class Channel
+
+      attr_reader :channel
+
+      def initialize(connection, configuration)
+        @channel = connection.create_channel
+        @configuration = configuration
+        # TODO: prefetch
+      end
+
+      # This is all copied from ChannelConnector.
+
+      def topic_exchange
+        @topic_exchange ||= channel.topic(configuration.topic_exchange_name, durable: true)
+      end
+
+      def delayed_exchange
+        raise_if_delayed_not_allowed
+        @delayed_exchange ||= channel.fanout(configuration.delayed_exchange_name, durable: true)
+      end
+
+      def delayed_queue
+        # This works by hacking the dead letter exchange concept with a timeout.
+        # We set up a delayed exchange that has a delayed queue.  This queue, configured below,
+        # sets its dead letter exchange to be the main exchange (topic_exchange above).
+        #
+        # This means that when a message send to the delayed queue is either nack'ed with no retry OR
+        # its TTL expires, it will be sent to the configured dead letter exchange, which is the main topic_exchange.
+        #
+        # Since nothing is actually consuming messages on the delayed queue, the only way messages can be removed and
+        # sent back to the main exchange is if their TTL expires.  As you can see in Pwwka::Transmitter#send_delayed_message!
+        # we set an expiration on the message and send it to the delayed exchange.  This means that the delay time is the TTL,
+        # so the messages sits in the delayed queue until its TTL/delay expires, and then it's sent onto the 
+        # main exchange for everyone to consume.  Thus creating a delay.
+        raise_if_delayed_not_allowed
+        @delayed_queue ||= begin
+                             queue = channel.queue(
+                               "pwwka_delayed_#{Pwwka.environment}",
+                               durable: true,
+                               arguments: {
+                                 'x-dead-letter-exchange' => configuration.topic_exchange_name,
+                               }
+                             )
+                             queue.bind(delayed_exchange)
+                             queue
+                           end
+      end
+      alias :create_delayed_queue :delayed_queue
+
+      def raise_if_delayed_not_allowed
+        unless configuration.allow_delayed?
+          raise ConfigurationError, "Delayed messages are not allowed. Update your configuration to allow them." 
+        end
+      end
+
+      private
+
+      attr_reader :configuration
+
+    end
+  end
+end

--- a/lib/pwwka/test_handler.rb
+++ b/lib/pwwka/test_handler.rb
@@ -33,10 +33,16 @@ module Pwwka
 
     # Get the message on the queue as TestHandler::Message
     def pop_message
-      delivery_info, properties, payload = test_queue.pop
-      Message.new(delivery_info,
-                  properties,
-                  payload)
+      # Since publishing happens in a background thread, we might need to wait a little bit.
+      5.times do
+        message = test_queue.pop
+        if message
+          return Message.new(*message)
+        else
+          sleep 0.1
+        end
+      end
+      raise "Failed to retrieve message after 5 tries"
     end
 
     def get_topic_message_payload_for_tests

--- a/lib/pwwka/test_handler.rb
+++ b/lib/pwwka/test_handler.rb
@@ -58,7 +58,7 @@ module Pwwka
     end
 
     def purge_test_queue
-      test_queue.purge  
+      test_queue.purge
       channel_connector.delayed_queue.purge if channel_connector.configuration.allow_delayed?
     end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -55,6 +55,9 @@ RSpec.configure do |config|
     example.run
     Pwwka.configuration.receive_raw_payload = false
   end
+  config.after(:each) do |example|
+    Pwwka::ConnectionRepository.reset!
+  end
   config.order = :random
   config.filter_run_excluding :legacy
 end

--- a/spec/unit/receiver_spec.rb
+++ b/spec/unit/receiver_spec.rb
@@ -17,16 +17,15 @@ describe Pwwka::Receiver do
     }
 
     before do
-      allow(Pwwka::ChannelConnector).to receive(:new).and_return(channel_connector)
+      allow(Pwwka.connections).to receive(:checkout).and_yield(channel_connector)
       allow(handler_klass).to receive(:handle!)
-      allow(channel_connector).to receive(:connection_close)
       allow(queue).to receive(:bind)
       allow(queue).to receive(:subscribe).and_yield({}, {}, '{}')
     end
 
     it 'sets the correct connection_name' do
       subject
-      expect(Pwwka::ChannelConnector).to have_received(:new).with(prefetch: nil, connection_name: "c: MyAwesomeApp my_awesome_process")
+      expect(Pwwka.connections).to have_received(:checkout).with(prefetch: nil, connection_name: "c: MyAwesomeApp my_awesome_process")
     end
 
     it 'logs on interrupt' do

--- a/spec/unit/transmitter_spec.rb
+++ b/spec/unit/transmitter_spec.rb
@@ -11,8 +11,8 @@ describe Pwwka::Transmitter do
     }
   }
   let(:routing_key) { "sf.foo.bar" }
-  let(:connection_repository) { class_double(Pwwka::ChannelConnector) }
-  let(:channel) { instance_double(Pwwka::ChannelConnector) }
+  let(:connection_repository) { instance_double(Pwwka::ConnectionRepository) }
+  let(:channel) { instance_double(Pwwka::ConnectionRepository::Channel) }
 
   before do
     @original_logger = Pwwka.configuration.logger


### PR DESCRIPTION
This is a WIP building on (and which will be developed in parallel with) #89.

The model here is one connection per process & one channel per thread. Right now, connections are automatically established when first retrieved in a given process. If the PID changes (after a fork) a new connection is established. A thread local variable is used to store this thread's channel. This makes it very important that the object yielded by `checkout` does not escape the block or get passed to another process or thread.

This PR needs new tests to ensure that both the persistent and non-persistent connectors are thoroughly integration tested. The persistent connector also needs integration tests to ensure that it appropriately recovers from errors. Bunny is supposed to handle reconnecting on errors, but we should verify that it works.

The ultimate goal here would be for persistent mode to be a setting you can flip on in the Pwwka configuration.

The difference between this and #88 is that it's meant to be a drop-in replacement for existing apps. #88 is less risky and helps us evaluate possible pitfalls with persistent connections, but it requires rewriting app code.