### PR TITLE
prefer Module#module_parent over deprecated Module#parent

### DIFF
--- a/lib/pwwka/configuration.rb
+++ b/lib/pwwka/configuration.rb
@@ -45,10 +45,15 @@ module Pwwka
     def app_id
       if @app_id.to_s.strip == ""
         if defined?(Rails)
-          if Rails.respond_to?(:application)
-            Rails.application.class.parent.name
+          if Rails.respond_to?(:application) && Rails.respond_to?(:version)
+            # Module#module_parent is the preferred technique, but we keep usage
+            # of the deprecated Module#parent for Rails 5 compatibility. see
+            # https://github.com/stitchfix/pwwka/issues/91 for context.
+            app_klass = Rails.application.class
+            app_parent = Rails.version =~ /^6/ ? app_klass.module_parent : app_klass.parent
+            app_parent.name
           else
-            raise "'Rails' is defined, but it doesn't respond to #application, so could not derive the app_id; you must explicitly set it"
+            raise "'Rails' is defined, but it doesn't respond to #application or #version, so could not derive the app_id; you must explicitly set it"
           end
         else
           raise "Could not derive the app_id; you must explicitly set it"

--- a/spec/unit/configuration_spec.rb
+++ b/spec/unit/configuration_spec.rb
@@ -75,6 +75,10 @@ describe Pwwka::Configuration do
           def self.application
             MyAmazingApp::Application.new
           end
+
+          def self.version
+            '5.2.0'
+          end
         end
         Object.const_set("Rails",rails)
       end
@@ -97,7 +101,7 @@ describe Pwwka::Configuration do
       it "blows up when not set" do
         expect {
           configuration.app_id
-        }.to raise_error(/'Rails' is defined, but it doesn't respond to #application, so could not derive the app_id; you must explicitly set it/)
+        }.to raise_error(/'Rails' is defined, but it doesn't respond to #application or #version, so could not derive the app_id; you must explicitly set it/)
       end
     end
   end


### PR DESCRIPTION
## Problem

When using Rails 6, the following deprecation warning is issued: 

```
DEPRECATION WARNING: `Module#parent` has been renamed to `module_parent`. `parent` is deprecated and will be removed in Rails 6.1. (called from <top (required)> at /Users/srinivasrao/Documents/stitchfix/question-set-service/config/environment.rb:13)
```

## Solution

use the recommended replacement, `Module#module_parent`, if available. 
