### PR TITLE
Explicitly call #to_json in synch error handling

### DIFF
--- a/lib/pwwka/transmitter.rb
+++ b/lib/pwwka/transmitter.rb
@@ -73,7 +73,10 @@ module Pwwka
 
         when :resque, :retry_async
           begin
-            send_message_async(payload, routing_key, delay_by_ms: delayed ? delay_by || DEFAULT_DELAY_BY_MS : 0)
+            # Both #send_delayed_message! and #send_message! both implicitly call #to_json on the payload.
+            # Adding this here to ensure that we have the same behavior when we have to switch over
+            # to async sending.
+            send_message_async(payload.to_json, routing_key, delay_by_ms: delayed ? delay_by || DEFAULT_DELAY_BY_MS : 0)
           rescue => exception
             warn(exception.message)
             raise e


### PR DESCRIPTION
## Problem

When sending a message using `#send_message!`, we have some error handling that catches an errors and handles them by potentially sending the message asynchronously.  But, there is a slight behavior difference in that `#send_message!` will always call `payload.to_json`, whereas the asynchronous sending will rely on the underlying job libraries serialization.  In the case of Resque, that turns out to be `MultiJson.encode`

This means that the payload for a given message could be different when sent synchronous versus asynchronous.

## Solution