### PR TITLE
Enqueue Resque jobs directly when there is no delay for an async message

### DIFF
--- a/lib/pwwka/transmitter.rb
+++ b/lib/pwwka/transmitter.rb
@@ -98,6 +98,14 @@ module Pwwka
         resque_args = [job, payload, routing_key]
 
         unless type == nil && message_id == :auto_generate && headers == nil
+          # NOTE: (jdlubrano)
+          # Why can't we pass these options all of the time?  Well, if a user
+          # of pwwka has configured their own async_job_klass that only has an
+          # arity of 2 (i.e. payload and routing key), then passing these options
+          # as an additional argument would break the user's application.  In
+          # order to maintain compatibility with preceding versions of Pwwka,
+          # we need to ensure that the same arguments passed into this method
+          # result in compatible calls to enqueue any Resque jobs.
           resque_args << { type: type, message_id: message_id, headers: headers }
         end
 

--- a/spec/unit/transmitter_spec.rb
+++ b/spec/unit/transmitter_spec.rb
@@ -312,19 +312,19 @@ describe Pwwka::Transmitter do
       end
       context "on_error: :resque" do
         it "queues a Resque job" do
-          allow(Resque).to receive(:enqueue_in)
+          allow(Resque).to receive(:enqueue)
           described_class.send_message!(payload,routing_key, on_error: :resque)
-          expect(Resque).to have_received(:enqueue_in).with(0,Pwwka::SendMessageAsyncJob,payload,routing_key)
+          expect(Resque).to have_received(:enqueue).with(Pwwka::SendMessageAsyncJob,payload,routing_key)
         end
         context "when there is a problem queueing the resque job" do
           it "raises the original exception job" do
-            allow(Resque).to receive(:enqueue_in).and_raise("NOPE")
+            allow(Resque).to receive(:enqueue).and_raise("NOPE")
             expect {
               described_class.send_message!(payload,routing_key, on_error: :resque)
             }.to raise_error(/OH NOES/)
           end
           it "logs the Resque error as a warning" do
-            allow(Resque).to receive(:enqueue_in).and_raise("NOPE")
+            allow(Resque).to receive(:enqueue).and_raise("NOPE")
             begin
               described_class.send_message!(payload,routing_key, on_error: :resque)
             rescue => ex
@@ -338,18 +338,18 @@ describe Pwwka::Transmitter do
         context "when configured background_job_processor is Resque" do
           context "when the job is queued successfully" do
             before do
-              allow(Resque).to receive(:enqueue_in)
+              allow(Resque).to receive(:enqueue)
             end
 
             it "queues a Resque job" do
               described_class.send_message!(payload, routing_key, on_error: :retry_async)
-              expect(Resque).to have_received(:enqueue_in).with(0, Pwwka::SendMessageAsyncJob, payload, routing_key)
+              expect(Resque).to have_received(:enqueue).with(Pwwka::SendMessageAsyncJob, payload, routing_key)
             end
           end
 
           context "when there is a problem queueing the Resque job" do
             before do
-              allow(Resque).to receive(:enqueue_in).and_raise("NOPE")
+              allow(Resque).to receive(:enqueue).and_raise("NOPE")
             end
 
             it "raises the original exception job" do


### PR DESCRIPTION
resque-scheduler has a bug that was fixed in https://github.com/resque/resque-scheduler/pull/689, but resque-scheduler has not had a release for over a year.  Stitch Fix experienced another incident in production in which resque-scheduler became a bottleneck for a high-traffic, async messaging use case.  This commit ensures that any non-delayed, async messages are enqueued to Resque directly effectively bypassing resque-scheduler when we want to publish a message in a background process but not explicitly delay the message.