### PR TITLE
remove per-message receipt logging

### DIFF
--- a/lib/pwwka/receiver.rb
+++ b/lib/pwwka/receiver.rb
@@ -31,7 +31,6 @@ module Pwwka
             payload = payload_parser.(payload)
             handler_klass.handle!(delivery_info, properties, payload)
             receiver.ack(delivery_info.delivery_tag)
-            logf "Processed Message on %{queue_name} -> %{payload}, %{routing_key}", queue_name: queue_name, payload: payload, routing_key: delivery_info.routing_key
           rescue => exception
             Pwwka::ErrorHandlers::Chain.new(
               Pwwka.configuration.error_handling_chain

--- a/lib/pwwka/receiver.rb
+++ b/lib/pwwka/receiver.rb
@@ -31,6 +31,7 @@ module Pwwka
             payload = payload_parser.(payload)
             handler_klass.handle!(delivery_info, properties, payload)
             receiver.ack(delivery_info.delivery_tag)
+            logf "Processed Message on %{queue_name} -> %{payload}, %{routing_key}", queue_name: queue_name, payload: payload, routing_key: delivery_info.routing_key, at: :debug
           rescue => exception
             Pwwka::ErrorHandlers::Chain.new(
               Pwwka.configuration.error_handling_chain


### PR DESCRIPTION
## Problem

Currently Pwwka logs the receipt of every message which generates a large amount of log data.

## Solution

Remove the per-message logging