### PR TITLE
Add a configurable hook to override log messages if the message text matches

### DIFF
--- a/README.md
+++ b/README.md
@@ -435,7 +435,7 @@ If you use [Resque][resque], and you wish to handle messages in a resque job, yo
 
    Note that you must provide `@queue` in your job.  `QueueResqueJobHandler` doesn't support setting a custom queue at enqueue-time (PRs welcome :).
 
-   Note that if you were using this library before version 0.12.0, your job would only be given the payload.  If you change your job to accept exatly three arguments, you will be given the payload, routing key, and message properties.  If any of those arguments are optional, you will need to set `PWWKA_QUEUE_EXTENDED_INFO` to `"true"` to force pwwka to pass those along.  Without it, your job only gets the payload to avoid breaking legacy consumers.
+   Note that if you were using this library before version 0.12.0, your job would only be given the payload.  If you change your job to accept exactly three arguments, you will be given the payload, routing key, and message properties.  If any of those arguments are optional, you will need to set `PWWKA_QUEUE_EXTENDED_INFO` to `"true"` to force pwwka to pass those along.  Without it, your job only gets the payload to avoid breaking legacy consumers.
 
 3. Profit!
 
@@ -530,6 +530,12 @@ If your payloads are large, you may not want to log them 2-3 times per message. 
 Pwwka.configuration.payload_logging = :info # The default - payloads appear at INFO and above log levels
 Pwwka.configuration.payload_logging = :error # Only log payloads for ERROR or FATAL messages
 Pwwka.configuration.payload_logging = :fatal # Only log payloads for FATAL messages
+```
+
+You can also hook into logging by passing a hash containing keys of strings to match and corresponding `Proc` objects for the logger to execute instead of logging a message. The `Proc` will be called with the original message string that was to be logged and the params specific for that log event. So, if for instance, you wanted to emit a count metric to your monitoring system instead of logging each processed message you could set the configuration:
+
+```ruby
+Pwwka.configuration.log_hooks = { 'Processed Message on' => ->(message, params){ $stats.count('message_processed') } }
 ```
 
 #### Manual monitoring

--- a/lib/pwwka/configuration.rb
+++ b/lib/pwwka/configuration.rb
@@ -10,6 +10,7 @@ module Pwwka
     attr_accessor :delayed_exchange_name
     attr_accessor :logger
     attr_accessor :log_level
+    attr_accessor :log_hooks
     attr_accessor :options
     attr_accessor :background_job_processor
     attr_accessor :send_message_resque_backoff_strategy
@@ -26,6 +27,7 @@ module Pwwka
       @delayed_exchange_name = "pwwka.delayed.#{Pwwka.environment}"
       @logger                = MonoLogger.new(STDOUT)
       @log_level             = :info
+      @log_hooks             = {}
       @options               = {}
       @send_message_resque_backoff_strategy = [5,                  #intermittent glitch?
                                                60,                 # quick interruption

--- a/lib/pwwka/logging.rb
+++ b/lib/pwwka/logging.rb
@@ -22,7 +22,10 @@ module Pwwka
         params[:payload] = "[omitted]" if params[:payload]
       end
       message = format % params
-      logger.send(level,message)
+
+      if Pwwka.configuration.log_hooks.select { |key, _value| message.match key }.each { |_key, value| value.call(message, params) }.empty?
+        logger.send(level,message)
+      end
     end
   end
 end


### PR DESCRIPTION
## Problem

Pwwka emits a lot of log messages under normal operating circumstances. Applications may not benefit from all these messages but may still want to do something with them (like emit a count metric).

## Solution

Introduce a configuration option to take a hash of patterns to match against the log option and if the pattern matches, call a corresponding `Proc` instead of logging the message.