### PR TITLE
Fix condition under which we pass extra args in transmitter (ACCT-521)

### DIFF
--- a/lib/pwwka/transmitter.rb
+++ b/lib/pwwka/transmitter.rb
@@ -106,7 +106,7 @@ module Pwwka
       if background_job_processor == :resque
         resque_args = [job, payload, routing_key]
 
-        unless type == nil && message_id == :auto_generate && headers == nil
+        unless type.nil? || message_id == :auto_generate || headers.nil?
           # NOTE: (jdlubrano)
           # Why can't we pass these options all of the time?  Well, if a user
           # of pwwka has configured their own async_job_klass that only has an

--- a/spec/unit/transmitter_spec.rb
+++ b/spec/unit/transmitter_spec.rb
@@ -71,6 +71,33 @@ describe Pwwka::Transmitter do
           )
         end
       end
+
+      context "with just the headers overridden" do
+        it "enqueues a Resque job with the various arguments including those headers" do
+          delay_by_ms = 3_000
+          described_class.send_message_async(
+            payload,
+            routing_key,
+            headers: {
+              "custom" => "value",
+              "other_custom" => "other_value",
+            },
+          )
+
+          expect(Resque).to have_received(:enqueue_in).with(
+            delay_by_ms / 1_000,
+            Pwwka::SendMessageAsyncJob,
+            payload,
+            routing_key,
+            type: nil,
+            message_id: :auto_generate,
+            headers: {
+              "custom" => "value",
+              "other_custom" => "other_value",
+            },
+          )
+        end
+      end
     end
 
     context "when the configured background_job_processor is Sidekiq" do


### PR DESCRIPTION
Found this bug while working on the Request Context gem.

Note that `if predicate && predicate` is _not_ equivalent to `unless
predicate && predicate` (but rather to `unless predicate || predicate`).

In this case, the change here from `if` to `unless` meant that we were
no longer sending a custom message ID, type, or headers unless _all_ of
the type, message ID, *and* headers had been changed from their
defaults.

This fix restores DeMorgan's faith in propositional logic by using the
correct operator `||` instead of `&&`.

See: https://stitchfix.atlassian.net/browse/ACCT-521.