### PR TITLE
[BUG#107] Ensure block should close connection only if using blocking subscription

### DIFF
--- a/lib/pwwka/receiver.rb
+++ b/lib/pwwka/receiver.rb
@@ -48,8 +48,16 @@ module Pwwka
         # TODO: trap TERM within channel.work_pool
         info "Interrupting queue #{queue_name} subscriber safely"
       ensure
-        receiver.channel_connector.connection_close
+        # If the subscription was created in a non-blocking fashion, do not
+        # close the underlying connection before returning (or the receiver
+        # will not be usable).
+        #
+        # For more information, see here:
+        #
+        # https://github.com/stitchfix/pwwka/issues/107
+        receiver.channel_connector.connection_close if block
       end
+
       return receiver
     end
 


### PR DESCRIPTION
## Problem

If the subscription was created in a non-blocking fashion, this ensure block will be hit before the receiver was returned, rending the receiver unusable. See #107 for more information.

## Solution

The `ensure` block should close the underlying connection only if the subscription blocked (because the asynchronously-delivered `Interrupt` would cause `Bunny::Queue#subscribe` to unwind). Subscriptions created in a non-blocking fashion should allow callers to handle signal trapping and connection teardown themselves.